### PR TITLE
Adding optional server-path override as an input for the build-gradle workflow

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -10,6 +10,10 @@ on:
       repo-name:
         required: false
         type: string
+      server-path:
+        required: false
+        type: string
+        default: 'server/jvm'
       product_name:
         required: true
         type: string
@@ -100,8 +104,8 @@ jobs:
           echo "genesis-home=../.genesis-home" >> ~/.gradle/gradle.properties
           echo "deploy-plugin-mode=local" >> ~/.gradle/gradle.properties
           sudo chmod +x ./gradlew
-          sudo chmod +x ./server/jvm/gradlew
-          sudo chmod -R +rx ./server/jvm/
+          sudo chmod +x ./${{ inputs.server-path }}/gradlew
+          sudo chmod -R +rx ./${{ inputs.server-path }}/
           cat ~/.gradle/gradle.properties >>  ./gradle.properties
           if [ -z "${{ inputs.repo-name }}" ]; then
             echo "REPO_NAME=$(echo '${{ github.event.repository.name }}' | cut -d'-' -f1)" >> $GITHUB_ENV
@@ -110,18 +114,18 @@ jobs:
           fi
           RELEASE_VERSION=$(echo "${{ inputs.version }}" | sed 's/\//-/g')
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
-          sed -E -i "s/^\s{4}version = \".+\"/    version = \"${RELEASE_VERSION}\"/g" server/jvm/build.gradle.kts
+          sed -E -i "s/^\s{4}version = \".+\"/    version = \"${RELEASE_VERSION}\"/g" ${{ inputs.server-path }}/build.gradle.kts
 
       - name: Server Build
         uses: gradle/gradle-build-action@v2
         with:
           arguments: build --no-build-cache --stacktrace -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }}
-          build-root-directory: ./server/jvm
+          build-root-directory: ./${{ inputs.server-path }}
           cache-disabled: true
 
       - name: Copy Test Reports
         run: |
-          for dir in /opt/actions-runner/_work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/server/jvm/*/build/reports/tests/test/; do
+          for dir in /opt/actions-runner/_work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/${{ inputs.server-path }}/*/build/reports/tests/test/; do
             if [ -d "$dir" ]; then
               subfolder_name=$(echo "$dir" | sed 's/.*\/jvm\///')
               echo "Subfolder Name: $subfolder_name"
@@ -156,7 +160,7 @@ jobs:
       - name: Create Giant Server Zip
         if: inputs.upload
         shell: bash
-        working-directory: server/jvm/
+        working-directory: ${{ inputs.server-path }}/
         run: |
           ./gradlew tasks | grep install- | cut -d " " -f1 | xargs ./gradlew
           cd .genesis-home
@@ -166,7 +170,7 @@ jobs:
 
       - name: Upload Server Package
         if: inputs.upload
-        working-directory: server/jvm/${{ inputs.product_name }}-distribution/build/distributions/
+        working-directory: ${{ inputs.server-path }}/${{ inputs.product_name }}-distribution/build/distributions/
         run: |
           echo "${{ env.REPO_NAME }}"
           curl -u ${{ secrets.JFROG_USERNAME }}:"${{secrets.JFROG_PASSWORD}}" -X PUT "https://genesisglobal.jfrog.io/artifactory/product/${{ env.REPO_NAME }}/server/" -T genesisproduct*.zip
@@ -231,7 +235,7 @@ jobs:
           echo "genesis-home=../.genesis-home" >> ~/.gradle/gradle.properties
           echo "deploy-plugin-mode=local" >> ~/.gradle/gradle.properties
           sudo chmod +x ./gradlew
-          sudo chmod +x ./server/jvm/gradlew
+          sudo chmod +x ./${{ inputs.server-path }}/gradlew
 
           cat ~/.gradle/gradle.properties >>  ./gradle.properties
           if [ -z "${{ inputs.repo-name }}" ]; then
@@ -241,7 +245,7 @@ jobs:
           fi
           RELEASE_VERSION=$(echo "${{ inputs.version }}" | sed 's/\//-/g')
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
-          sed -E -i "s/^\s{4}version = \".+\"/    version = \"${RELEASE_VERSION}\"/g" server/jvm/build.gradle.kts
+          sed -E -i "s/^\s{4}version = \".+\"/    version = \"${RELEASE_VERSION}\"/g" ${{ inputs.server-path }}/build.gradle.kts
 
       - name: Check file existence
         id: web_exists


### PR DESCRIPTION
Why:
Currently, the [gradle-build](https://github.com/genesislcap/appdev-workflows/blob/develop/.github/workflows/build-gradle.yml#L165) uses a hardcoded server/jvm path to build the server module. The position-docker-app however relies on a different structure.

What:
Added an optional server-path input var. If not set, we fallback to the previous behaviour.