### PR TITLE
feat: exposing capability for users to supply additional server arguments during build

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -50,6 +50,10 @@ on:
         type: string
         default: .
         required: false
+      server-gradle-arguments:
+        type: string
+        description: Additional arguments/properties to be passed to the server gradle build command
+        required: false
 
     secrets:
       GRADLE_PROPERTIES:
@@ -120,7 +124,7 @@ jobs:
       - name: Server Build
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build --no-build-cache --stacktrace -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }}
+          arguments: build --no-build-cache --stacktrace -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }} ${{ inputs.server-gradle-arguments }}
           build-root-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
           cache-disabled: true
 


### PR DESCRIPTION
# What it is

Exposes an additional optional input parameter in the `build-gradle.yml` workflow so that users can pass additional properties/params to the gradle build command, this is usefull when overriding certain properties or to execute additional tasks as part of the build.

This approach has been extensively used in the platform release repo for our nightly jobs. See example here: https://github.com/genesislcap/platform-releases/blob/master/.github/workflows/gradle-branch-workflow.yml#L47


