### PR TITLE
[TPD-3742] - Replace version in gradle.properties as well as build.gradle.kts (build-gradle.yml)

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -144,6 +144,7 @@ jobs:
           RELEASE_VERSION=$(echo "${{ inputs.version }}" | sed 's/\//-/g')
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
           sed -E -i "s/^\s{4}version = \".+\"/    version = \"${RELEASE_VERSION}\"/g" ${{ inputs.server-path }}/build.gradle.kts
+          sed -E -i "s/version=.+/version=${RELEASE_VERSION}/g" ${{ inputs.server-path }}/gradle.properties
 
       - name: Server Build
         uses: gradle/gradle-build-action@v2


### PR DESCRIPTION
Now that tam2-server has site-specific folders using the artifactory gradle plugin, the versions are unified in a `gradle.properties` file. Replacing the version in `build.gradle.kts` won't affect these site-specific projects, so it needs to be in `gradle.properties`