### PR TITLE
Remove DEBUG log level from JFrog scan

### DIFF
--- a/build-image/jfrog-scanning/action.yaml
+++ b/build-image/jfrog-scanning/action.yaml
@@ -24,7 +24,6 @@ runs:
         JF_URL: https://genesisglobal.jfrog.io
         JF_USER: ${{ inputs.jfrog-username }}
         JF_PASSWORD: ${{ inputs.jfrog-password }}
-        JFROG_CLI_LOG_LEVEL: DEBUG
 
     - name: Check if appDistZip exists
       shell: bash
@@ -45,8 +44,6 @@ runs:
         ./gradlew appDistZip -Pversion=${{ inputs.version }} -PgenesisArtifactoryUser="${{ inputs.jfrog-username }}" -PgenesisArtifactoryPassword="${{ inputs.jfrog-password }}"
 
     - name: Run the JFrog scan
-      env:
-        JFROG_CLI_LOG_LEVEL: DEBUG
       if: steps.check_task.outputs.appDistZip == 'true'
       shell: bash
       working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/


### PR DESCRIPTION
Removed JFROG_CLI_LOG_LEVEL environment variable from the JFrog scan step.