### PR TITLE
Support passing additional build arguments to buildImage action

### DIFF
--- a/build-image/action.yaml
+++ b/build-image/action.yaml
@@ -32,6 +32,9 @@ inputs:
   test-reports-suffix:
     required: false
     default: ""
+  build-image:
+    required: false
+    default: "true"
   push-image:
     required: false
     default: "true"
@@ -141,7 +144,7 @@ runs:
         server-path: ${{ inputs.server-path }}
 
     - name: Build Image
-      if: inputs.push-image == 'true'
+      if: inputs.build-image == 'true'
       shell: bash
       working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
       run: |

--- a/build-image/action.yaml
+++ b/build-image/action.yaml
@@ -100,7 +100,7 @@ runs:
       shell: bash
       run: |
         # sensible to customization
-        project_name=$(egrep "(rootProject|productName)" settings.gradle.kts | sed -n -E 's/.*(genesisproduct-|productName *= *")([^"]+)".*/\2/p')
+        project_name=$(egrep "(rootProject|productName)" settings.gradle.kts | sed -n -E 's/.*(genesisproduct-|productName *= *")([^"]+)".*/\2/p' | head -n 1)
 
         echo "PRODUCT_NAME=${project_name}" >> $GITHUB_ENV
       working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/

--- a/build-image/action.yaml
+++ b/build-image/action.yaml
@@ -32,6 +32,9 @@ inputs:
   test-reports-suffix:
     required: false
     default: ""
+  run-tests:
+    required: false
+    default: "true"
   build-image:
     required: false
     default: "true"
@@ -134,6 +137,7 @@ runs:
         server-path: ${{ inputs.server-path }}
 
     - name: Run Tests
+      if: inputs.run-tests == 'true'
       uses: genesislcap/appdev-workflows/build-image/run-tests@develop
       with:
         version: ${{ inputs.version }}

--- a/build-image/action.yaml
+++ b/build-image/action.yaml
@@ -39,7 +39,7 @@ inputs:
     required: false
     default: true
     type: boolean
-  server-build-gradle-arguments:
+  build-image-arguments:
     type: string
     description: Additional arguments/properties to be passed to the buildImage gradle command
     required: false

--- a/build-image/action.yaml
+++ b/build-image/action.yaml
@@ -39,6 +39,10 @@ inputs:
     required: false
     default: true
     type: boolean
+  server-build-gradle-arguments:
+    type: string
+    description: Additional arguments/properties to be passed to the buildImage gradle command
+    required: false
 
 runs:
   using: "composite"
@@ -141,7 +145,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
       run: |
-        ./gradlew buildImage -Pversion=${{ inputs.version }} --no-configuration-cache --no-build-cache --stacktrace -PgenesisArtifactoryUser="${{ inputs.jfrog-username }}" -PgenesisArtifactoryPassword="${{ inputs.jfrog-password }}"
+        ./gradlew buildImage -Pversion=${{ inputs.version }} --no-configuration-cache --no-build-cache --stacktrace -PgenesisArtifactoryUser="${{ inputs.jfrog-username }}" -PgenesisArtifactoryPassword="${{ inputs.jfrog-password }}" ${{ inputs.server-build-gradle-arguments }}
 
     - name: Push Image using bash
       if: inputs.push-image == 'true'


### PR DESCRIPTION
Added an input for additional Gradle arguments to the buildImage command. This is to allow TAM to pass a gradle property which will specify the client site-specific to use in the image.