### PR TITLE
Allow running integration tests as separate gradle task

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -282,7 +282,7 @@ jobs:
 
       - name: Integration tests
         if: ${{ !inputs.skip-tests && inputs.int-test-module }}
-        run: ./gradlew :${{ inputs.int-test-module }}:test --stacktrace -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }} ${{ inputs.server-build-gradle-arguments }} ${{ env.CACHE_OPTS }}
+        run: ./gradlew :${{ inputs.int-test-module }}:test --stacktrace -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }} ${{ env.CACHE_OPTS }}
         working-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
       
       - name: Server Assemble

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -239,14 +239,15 @@ jobs:
           cache-write-only: ${{ inputs.cache-write-only }}
           cache-disabled: ${{ inputs.disable-cache }}
 
-      - name: Scan artifact
-        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@develop
-        with:
-          version: ${{ env.RELEASE_VERSION }}
-          jfrog-username: ${{ secrets.JFROG_USERNAME }}
-          jfrog-password: ${{ secrets.JFROG_PASSWORD }}
-          working-directory: ${{ inputs.working-directory }}
-          server-path: ${{ inputs.server-path }}
+# temp ignore
+      # - name: Scan artifact
+      #   uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@develop
+      #   with:
+      #     version: ${{ env.RELEASE_VERSION }}
+      #     jfrog-username: ${{ secrets.JFROG_USERNAME }}
+      #     jfrog-password: ${{ secrets.JFROG_PASSWORD }}
+      #     working-directory: ${{ inputs.working-directory }}
+      #     server-path: ${{ inputs.server-path }}
 
       - name: Install Sast CLI
         if: inputs.sast
@@ -276,12 +277,12 @@ jobs:
 
       - name: Server Build
         if: ${{ !inputs.skip-tests }}
-        run: ./gradlew build --stacktrace -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }} ${{ inputs.server-build-gradle-arguments }} ${{ env.CACHE_OPTS }}
+        run: ./gradlew build ${{ inputs.int-test-module && format('-x :{0}:test', inputs.int-test-module) || '' }} --stacktrace -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }} ${{ inputs.server-build-gradle-arguments }} ${{ env.CACHE_OPTS }}
         working-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
 
-      - name: Int tests
+      - name: Integration tests
         if: ${{ !inputs.skip-tests && inputs.int-test-module }}
-        run: ./gradlew ${{ inputs.int-test-module }}:test --stacktrace -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }} ${{ inputs.server-build-gradle-arguments }} ${{ env.CACHE_OPTS }}
+        run: ./gradlew :${{ inputs.int-test-module }}:test --stacktrace -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }} ${{ inputs.server-build-gradle-arguments }} ${{ env.CACHE_OPTS }}
         working-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
       
       - name: Server Assemble

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -242,11 +242,11 @@ jobs:
       - name: Scan artifact
         uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@develop
         with:
-         version: ${{ env.RELEASE_VERSION }}
-         jfrog-username: ${{ secrets.JFROG_USERNAME }}
-         jfrog-password: ${{ secrets.JFROG_PASSWORD }}
-         working-directory: ${{ inputs.working-directory }}
-         server-path: ${{ inputs.server-path }}
+          version: ${{ env.RELEASE_VERSION }}
+          jfrog-username: ${{ secrets.JFROG_USERNAME }}
+          jfrog-password: ${{ secrets.JFROG_PASSWORD }}
+          working-directory: ${{ inputs.working-directory }}
+          server-path: ${{ inputs.server-path }}
 
       - name: Install Sast CLI
         if: inputs.sast

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -108,6 +108,11 @@ on:
         required: false
         default: true
         type: boolean
+      int-test-module:
+        description: "Int test module"
+        required: false
+        type: string
+        default: ""
 
 
     secrets:
@@ -272,6 +277,11 @@ jobs:
       - name: Server Build
         if: ${{ !inputs.skip-tests }}
         run: ./gradlew build --stacktrace -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }} ${{ inputs.server-build-gradle-arguments }} ${{ env.CACHE_OPTS }}
+        working-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
+
+      - name: Int tests
+        if: ${{ !inputs.skip-tests && inputs.int-test-module }}
+        run: ./gradlew ${{ inputs.int-test-module }}:test --stacktrace -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }} ${{ inputs.server-build-gradle-arguments }} ${{ env.CACHE_OPTS }}
         working-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
       
       - name: Server Assemble

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -277,12 +277,12 @@ jobs:
 
       - name: Server Build
         if: ${{ !inputs.skip-tests }}
-        run: ./gradlew build ${{ inputs.int-test-module && format('-x :{0}:test', inputs.int-test-module) || '' }} --stacktrace -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }} ${{ inputs.server-build-gradle-arguments }} ${{ env.CACHE_OPTS }}
+        run: ./gradlew build ${{ inputs.int-test-module && format('-x :{0}:test', inputs.int-test-module) || '' }} --stacktrace -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }} ${{ inputs.server-build-gradle-arguments }} ${{ env.CACHE_OPTS }} --no-daemon
         working-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
 
       - name: Integration tests
         if: ${{ !inputs.skip-tests && inputs.int-test-module }}
-        run: ./gradlew :${{ inputs.int-test-module }}:test --stacktrace -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }} ${{ env.CACHE_OPTS }}
+        run: ./gradlew :${{ inputs.int-test-module }}:test --stacktrace -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }} ${{ env.CACHE_OPTS }} --no-daemon
         working-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
       
       - name: Server Assemble

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -240,7 +240,7 @@ jobs:
           cache-disabled: ${{ inputs.disable-cache }}
 
       - name: Scan artifact
-        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@develop
+        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@khouari1-patch-3
         with:
           version: ${{ env.RELEASE_VERSION }}
           jfrog-username: ${{ secrets.JFROG_USERNAME }}

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -239,15 +239,14 @@ jobs:
           cache-write-only: ${{ inputs.cache-write-only }}
           cache-disabled: ${{ inputs.disable-cache }}
 
-# temp ignore
-      # - name: Scan artifact
-      #   uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@develop
-      #   with:
-      #     version: ${{ env.RELEASE_VERSION }}
-      #     jfrog-username: ${{ secrets.JFROG_USERNAME }}
-      #     jfrog-password: ${{ secrets.JFROG_PASSWORD }}
-      #     working-directory: ${{ inputs.working-directory }}
-      #     server-path: ${{ inputs.server-path }}
+      - name: Scan artifact
+        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@develop
+        with:
+         version: ${{ env.RELEASE_VERSION }}
+         jfrog-username: ${{ secrets.JFROG_USERNAME }}
+         jfrog-password: ${{ secrets.JFROG_PASSWORD }}
+         working-directory: ${{ inputs.working-directory }}
+         server-path: ${{ inputs.server-path }}
 
       - name: Install Sast CLI
         if: inputs.sast

--- a/build-image/jfrog-scanning/action.yaml
+++ b/build-image/jfrog-scanning/action.yaml
@@ -32,7 +32,7 @@ runs:
       id: check_task
       working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
       run: |
-        if ./gradlew tasks --all -Pversion=${{ inputs.version }} -PgenesisArtifactoryUser="${{ inputs.jfrog-username }}" -PgenesisArtifactoryPassword="${{ inputs.jfrog-password }}" | grep -q "appDistZip"; then
+        if ./gradlew tasks --all -Pversion=${{ inputs.version }} -PgenesisArtifactoryUser="${{ inputs.jfrog-username }}" -PgenesisArtifactoryPassword="${{ inputs.jfrog-password }}" --no-daemon | grep -q "appDistZip"; then
           echo "appDistZip=true" >> $GITHUB_OUTPUT
         else
           echo "appDistZip=false" >> $GITHUB_OUTPUT
@@ -43,7 +43,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
       run: |
-        ./gradlew appDistZip -Pversion=${{ inputs.version }} -PgenesisArtifactoryUser="${{ inputs.jfrog-username }}" -PgenesisArtifactoryPassword="${{ inputs.jfrog-password }}"
+        ./gradlew appDistZip -Pversion=${{ inputs.version }} -PgenesisArtifactoryUser="${{ inputs.jfrog-username }}" -PgenesisArtifactoryPassword="${{ inputs.jfrog-password }}" --no-daemon
 
     - name: Run the JFrog scan
       if: steps.check_task.outputs.appDistZip == 'true'


### PR DESCRIPTION
This is to help reclaim memory as integration tests often have a large memory footprint, as in TAM's case.