### PR TITLE
Force fetch tags

### DIFF
--- a/.github/workflows/set-fix-version.yml
+++ b/.github/workflows/set-fix-version.yml
@@ -88,7 +88,9 @@ jobs:
           mkdir -p "$(dirname "$CSV_FILE")"
           echo "CommitJiraID,NewIssueKey,Project,Summary,Status,FixVersions" > "$CSV_FILE"
 
-          git fetch --tags
+          # actions/checkout may materialize the current ref as the peeled commit for
+          # annotated tags; force-refresh tags so subsequent tag lookups stay consistent.
+          git fetch --force --tags origin
           COMMITS=$(git log $PREV_TAG..$CUR_TAG --pretty=format:"%H %s")
 
           declare -A seen_jiras


### PR DESCRIPTION
We're running this workflow on tag creation trigger. The `git fetch --tags` was causing the workflow to fail https://github.com/genesislcap/tam2-server/actions/runs/23305795703/job/67784746778 because the same tag that triggered the workflow is being overwritten. Force fetching tags so this can work