### PR TITLE
feat: Add build-server-arguments input to scanning workflow (DCD-4650)

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -253,6 +253,7 @@ jobs:
           working-directory: ${{ inputs.working-directory }}
           server-path: ${{ inputs.server-path }}
           app-name: ${{ inputs.product_name }}
+          build-server-arguments: ${{ inputs.server-build-gradle-arguments }}
 
       - name: Install Sast CLI
         if: inputs.sast


### PR DESCRIPTION
In TAM we need to pass custom build arguments depending on client