### PR TITLE
fix: reinstated tools (DCD-4607)

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -113,6 +113,7 @@ jobs:
                   },
                   "includeTools": [
                     "pull_request_read",
+                    "add_issue_comment",
                     "pull_request_review_write",
                     "add_comment_to_pending_review"
                   ]

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -113,7 +113,8 @@ jobs:
                   },
                   "includeTools": [
                     "pull_request_read",
-                    "add_issue_comment"
+                    "pull_request_review_write",
+                    "add_comment_to_pending_review"
                   ]
                 }
               },


### PR DESCRIPTION
Reinstated "add_issue_comment", "pull_request_review_write", "add_comment_to_pending_review" tools, to allow inline comments