### PR TITLE
fix: add if guard to backport workflow so consumers only need the trigger (DCD-0)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,12 +13,13 @@ jobs:
   backport:
     name: Backport pull request
     runs-on: ubuntu-latest
-    # 97796249 is the ID of the bot https://api.github.com/users/backport-action
     if: >
       (
         github.event_name == 'pull_request_target' &&
         github.event.pull_request.merged
-      ) || (
+      )
+
+      || (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         github.event.comment.user.id != 97796249 &&

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,6 +13,17 @@ jobs:
   backport:
     name: Backport pull request
     runs-on: ubuntu-latest
+    # 97796249 is the ID of the bot https://api.github.com/users/backport-action
+    if: >
+      (
+        github.event_name == 'pull_request_target' &&
+        github.event.pull_request.merged
+      ) || (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        github.event.comment.user.id != 97796249 &&
+        startsWith(github.event.comment.body, '/backport')
+      )
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Problem

The shared backport workflow has no `if` condition on the job — it runs the backport action unconditionally on every call. The `if` guard that filters for merged PRs vs `/backport` comments currently lives only in each consuming repo's local wrapper (e.g. `platform-notify`).

This creates a subtle trap: when a consuming repo migrates to this shared workflow, they must remember to keep the `if` condition in their local wrapper. If they forget (as happened with `platform-notify` in GSF-007), the workflow runs on every merged PR regardless of labels, and `/backport` comment support is lost silently.

A companion issue: the `issue_comment` trigger must always be declared in the consuming repo's local `on:` block — that's unavoidable with `workflow_call` architecture — but the `if` condition can and should live here in the shared workflow.

## Fix

Add the same `if` condition that GSF's standalone `backport.yml` uses. Since `workflow_call` inherits `github.event_name` and `github.event` from the calling workflow's context, the condition evaluates correctly for both `pull_request_target` and `issue_comment` events.

## Effect on consuming repos

- Consuming repo wrappers no longer need to duplicate the `if` condition.
- They still must declare `issue_comment: [created]` in their `on:` block (GitHub constraint — `workflow_call` can't add cross-repo event triggers).
- Existing wrappers that already have the `if` condition are unaffected (double-guard is harmless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)