### PR TITLE
fix: build workflow (DCD-4835)

### DIFF
--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -216,6 +216,17 @@ jobs:
         with:
           config-path: ${{ inputs.config-path }}
 
+      - name: Scan artifact
+        if: inputs.jfrogscan
+        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analyis
+        with:
+          version: ${{ env.RELEASE_VERSION }}
+          jfrog-username: ${{ secrets.JFROG_USERNAME }}
+          jfrog-password: ${{ secrets.JFROG_PASSWORD }}
+          working-directory: ${{ inputs.working-directory }}
+          server-path: "${{ inputs.working-directory }}/server"
+          app-name: ${{ inputs.product_name }}
+
       - name: Install Bearer CLI
         if: inputs.sast
         working-directory: "${{ inputs.working-directory }}"
@@ -249,19 +260,6 @@ jobs:
           cache-disabled: true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-
-      # Runs after the build so Gradle's appDistZip task finds its outputs already
-      # on disk and completes as UP-TO-DATE, avoiding a second full compilation.
-      - name: Scan artifact
-        if: inputs.jfrogscan
-        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analyis
-        with:
-          version: ${{ env.RELEASE_VERSION }}
-          jfrog-username: ${{ secrets.JFROG_USERNAME }}
-          jfrog-password: ${{ secrets.JFROG_PASSWORD }}
-          working-directory: ${{ inputs.working-directory }}
-          server-path: "${{ inputs.working-directory }}/server"
-          app-name: ${{ inputs.product_name }}
 
       - name: Test and Coverage
         if: inputs.sonar_enabled

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -216,16 +216,16 @@ jobs:
         with:
           config-path: ${{ inputs.config-path }}
 
-      - name: Scan artifact
-        if: inputs.jfrogscan
-        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analyis
-        with:
-          version: ${{ env.RELEASE_VERSION }}
-          jfrog-username: ${{ secrets.JFROG_USERNAME }}
-          jfrog-password: ${{ secrets.JFROG_PASSWORD }}
-          working-directory: ${{ inputs.working-directory }}
-          server-path: "${{ inputs.working-directory }}/server"
-          app-name: ${{ inputs.product_name }}
+#      - name: Scan artifact
+#        if: inputs.jfrogscan
+#        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analyis
+#        with:
+#          version: ${{ env.RELEASE_VERSION }}
+#          jfrog-username: ${{ secrets.JFROG_USERNAME }}
+#          jfrog-password: ${{ secrets.JFROG_PASSWORD }}
+#          working-directory: ${{ inputs.working-directory }}
+#          server-path: "${{ inputs.working-directory }}/server"
+#          app-name: ${{ inputs.product_name }}
 
       - name: Install Bearer CLI
         if: inputs.sast

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -259,8 +259,8 @@ jobs:
           build-root-directory: "${{ inputs.working-directory }}"
           cache-disabled: true
         env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}     
-      
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
 
       - name: Test and Coverage
         if: inputs.sonar_enabled

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -45,9 +45,8 @@ on:
       enable-pr-cache:
         type: boolean
         description: >-
-          PR builds only. When true, scopes Gradle cache per client repo and PR
-          (GitHub Actions cache + isolated GRADLE_USER_HOME + --build-cache).
-          No effect on push/tag.
+          PR builds only. Opt-in: true = per-PR GHA cache + isolated GRADLE_USER_HOME + --build-cache.
+          Opt-out / false / push to develop = ~/.gradle, --no-build-cache, no GHA cache steps.
         default: false
         required: false
       working-directory:
@@ -130,7 +129,9 @@ concurrency:
 env:
   NODE_AUTH_TOKEN: ${{secrets.GPR_READ_TOKEN}}
   DISTRIBUTION_DIR: ${{ inputs.distribution_dir || format('{0}-distribution', inputs.product_name) }}
+  # Opt-out: --no-build-cache. Opt-in (PR + enable-pr-cache): --build-cache.
   CACHE_OPTS: ${{ (github.event_name != 'pull_request' || !inputs.enable-pr-cache) && '--no-build-cache --no-configuration-cache' || '--build-cache' }}
+  # Empty when opt-out; set to owner-repo-pr-N when opt-in (gates all GHA cache steps).
   PR_CACHE_SCOPE: ${{ github.event_name == 'pull_request' && inputs.enable-pr-cache && format('{0}-{1}-pr-{2}', github.repository_owner, github.event.repository.name, github.event.pull_request.number) || '' }}
   GRADLE_GENESIS_PUSH_TO_CACHE: ${{ (github.event_name != 'pull_request' || !inputs.enable-pr-cache) && inputs.push-to-artifactory-cache }}
   GRADLE_GENESIS_DISABLE_REMOTE_CACHE: ${{ (github.event_name == 'pull_request' && inputs.enable-pr-cache) || !inputs.use-artifactory-cache }}
@@ -138,6 +139,9 @@ env:
 jobs:
   build-server:
     runs-on: [ appdev-selfhosted-al2023 ]
+    permissions:
+      contents: read # clone repo (actions/checkout)
+      actions: write # delete/save GHA Gradle cache when enable-pr-cache is true
     steps:
       - uses: actions/checkout@v3
         with:
@@ -180,12 +184,14 @@ jobs:
         shell: bash
         run: |
           if [ -n "${{ env.PR_CACHE_SCOPE }}" ]; then
+            # Cache opt-in: isolated GRADLE_USER_HOME per PR
             GRADLE_HOME_DIR="${RUNNER_TEMP}/gradle-${{ env.PR_CACHE_SCOPE }}"
             mkdir -p "${GRADLE_HOME_DIR}"
             echo "GRADLE_USER_HOME=${GRADLE_HOME_DIR}" >> "$GITHUB_ENV"
             echo "PR_CACHE_SCOPE=${{ env.PR_CACHE_SCOPE }}" >> "$GITHUB_ENV"
             echo "Using PR-isolated GRADLE_USER_HOME: ${GRADLE_HOME_DIR}"
           else
+            # Cache opt-out: default ~/.gradle, no PR GHA cache
             mkdir -p "${HOME}/.gradle"
             GRADLE_HOME_DIR="${HOME}/.gradle"
             echo "GRADLE_USER_HOME=${GRADLE_HOME_DIR}" >> "$GITHUB_ENV"
@@ -220,6 +226,7 @@ jobs:
 
           echo "GENX_BUILD_INFO=${{ github.ref_name }} / $(date -u +'%Y-%m-%d-%H%M%S') / $(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
+      # Cache opt-in only (PR_CACHE_SCOPE set). Opt-out skips restore/delete/save entirely.
       - name: Restore Gradle cache (PR-scoped)
         if: env.PR_CACHE_SCOPE != ''
         uses: actions/cache/restore@v4
@@ -366,6 +373,28 @@ jobs:
             ./**/build/test-results/**/*.xml
           fail_on: nothing
           report_suite_logs: any
+
+      # Opt-in: drop prior keys for this PR, then save one entry ({scope}-{run_id}).
+      - name: Delete existing PR Gradle cache (before save)
+        if: success() && env.PR_CACHE_SCOPE != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prefix = `${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-`;
+            const { owner, repo } = context.repo;
+            const { data } = await github.rest.actions.getActionsCacheList({
+              owner,
+              repo,
+              key: prefix,
+              per_page: 100,
+            });
+            for (const cache of data.actions_caches ?? []) {
+              await github.rest.actions.deleteActionsCacheById({
+                owner,
+                repo,
+                cache_id: cache.id,
+              });
+            }
 
       - name: Save Gradle cache (PR-scoped)
         if: success() && env.PR_CACHE_SCOPE != ''

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -261,6 +261,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-
 
+      # Exact key on server sources only (no restore-keys) so scan reuses dist when code unchanged.
+      - name: Restore dist zip cache (PR-scoped)
+        if: env.PR_CACHE_SCOPE != ''
+        uses: actions/cache@v4
+        with:
+          path: ${{ inputs.working-directory }}/server/*/build/dist
+          key: ${{ runner.os }}-dist-${{ env.PR_CACHE_SCOPE }}-${{ hashFiles(format('{0}/server/**/*.kt', inputs.working-directory), format('{0}/server/**/*.java', inputs.working-directory), format('{0}/server/**/*.kts', inputs.working-directory), format('{0}/server/**/build.gradle.kts', inputs.working-directory), format('{0}/server/**/build.gradle', inputs.working-directory)) }}
+
       - name: 'Create .npmrc'
         shell: bash
         run: |

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -42,6 +42,13 @@ on:
         description: Push to the Artifactory cache
         default: false
         required: false
+      enable-pr-cache:
+        type: boolean
+        description: >-
+          PR builds only. When true (and use-artifactory-cache is true), enables Gradle build
+          cache and Artifactory remote cache for pull_request events. No effect on push/tag.
+        default: false
+        required: false
       working-directory:
         type: string
         default: .
@@ -114,10 +121,15 @@ on:
       SENTRY_AUTH_TOKEN:
         required: false
 
+# PR number is only set on pull_request; for push/tag use event + ref (see reverted PR #168).
+concurrency:
+  group: build-${{ github.repository }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('{0}-{1}', github.event_name, github.ref) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && !inputs.enable-pr-cache }}
 
 env:
   NODE_AUTH_TOKEN: ${{secrets.GPR_READ_TOKEN}}
   DISTRIBUTION_DIR: ${{ inputs.distribution_dir || format('{0}-distribution', inputs.product_name) }}
+  CACHE_OPTS: ${{ (github.event_name != 'pull_request' || !inputs.enable-pr-cache) && '--no-build-cache --no-configuration-cache' || '' }}
 
 # A workflow run is called from the devops appdev-workflow repos
 jobs:
@@ -255,9 +267,9 @@ jobs:
       - name: Build
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build --no-build-cache --no-configuration-cache --stacktrace -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }} ${{ inputs.server-build-gradle-arguments }}
+          arguments: build ${{ env.CACHE_OPTS }} --stacktrace -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ (github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache) }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache) }} ${{ inputs.server-build-gradle-arguments }}
           build-root-directory: "${{ inputs.working-directory }}"
-          cache-disabled: true
+          cache-disabled: ${{ github.event_name != 'pull_request' || !inputs.enable-pr-cache }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -135,9 +135,8 @@ env:
   GRADLE_PUSH_TO_REMOTE_CACHE: ${{ (github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache) }}
   GRADLE_DISABLE_REMOTE_CACHE: ${{ !inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache) }}
   # PR scope: -PpushToCache=false disables Genesis shared remote only; Gradle HTTP remote stays on (init.d).
-  GRADLE_GENESIS_PUSH_TO_CACHE: ${{ env.PR_CACHE_SCOPE == '' && ((github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache)) || false }}
-  GRADLE_GENESIS_DISABLE_REMOTE_CACHE: ${{ env.PR_CACHE_SCOPE == '' && (!inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache)) }}
-  PR_SERVER_HASH: ${{ hashFiles(format('{0}/server/**/*.kt', inputs.working-directory), format('{0}/server/**/*.java', inputs.working-directory), format('{0}/server/**/*.kts', inputs.working-directory), format('{0}/server/**/build.gradle.kts', inputs.working-directory), format('{0}/server/**/build.gradle', inputs.working-directory)) }}
+  GRADLE_GENESIS_PUSH_TO_CACHE: ${{ (github.event_name != 'pull_request' || !inputs.enable-pr-cache) && ((github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache)) || false }}
+  GRADLE_GENESIS_DISABLE_REMOTE_CACHE: ${{ (github.event_name != 'pull_request' || !inputs.enable-pr-cache) && (!inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache)) }}
 
 # A workflow run is called from the devops appdev-workflow repos
 jobs:
@@ -148,6 +147,12 @@ jobs:
         with:
           fetch-depth: '0'
           ref: ${{ inputs.branch }}
+
+      - name: Set PR server source hash
+        if: env.PR_CACHE_SCOPE != ''
+        env:
+          PR_SERVER_HASH: ${{ hashFiles(format('{0}/server/**/*.kt', inputs.working-directory), format('{0}/server/**/*.java', inputs.working-directory), format('{0}/server/**/*.kts', inputs.working-directory), format('{0}/server/**/build.gradle.kts', inputs.working-directory), format('{0}/server/**/build.gradle', inputs.working-directory)) }}
+        run: echo "PR_SERVER_HASH=${PR_SERVER_HASH}" >> "$GITHUB_ENV"
 
       - name: Set up JDK
         uses: actions/setup-java@v2

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -248,9 +248,8 @@ jobs:
           build-root-directory: "${{ inputs.working-directory }}"
           cache-disabled: true
         env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-
-      # Runs after Build so appDistZip reuses compiled outputs (UP-TO-DATE) instead of a second full build.
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}     
+      
       - name: Scan artifact
         if: inputs.jfrogscan
         uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analyis
@@ -259,10 +258,8 @@ jobs:
           jfrog-username: ${{ secrets.JFROG_USERNAME }}
           jfrog-password: ${{ secrets.JFROG_PASSWORD }}
           working-directory: ${{ inputs.working-directory }}
-          server-path: server
-          build-server-arguments: ${{ inputs.server-build-gradle-arguments }}
+          server-path: "${{ inputs.working-directory }}/server"
           app-name: ${{ inputs.product_name }}
-
       - name: Test and Coverage
         if: inputs.sonar_enabled
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -285,7 +285,7 @@ jobs:
 
       - name: Scan artifact
         if: inputs.jfrogscan
-        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@workflow_jrog_cache
+        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@workflow_jfrog_cache
         with:
           version: ${{ env.RELEASE_VERSION }}
           jfrog-username: ${{ secrets.JFROG_USERNAME }}

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -122,7 +122,7 @@ env:
 # A workflow run is called from the devops appdev-workflow repos
 jobs:
   build-server:
-    runs-on: [ appdev-selfhosted-al2023 ]
+    runs-on: [ self-hosted, selfhosted-services ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -212,7 +212,7 @@ jobs:
 
       - name: Read .env file for build
         if: ${{ inputs.config-path }}
-        uses: genesislcap/appdev-workflows/read-dot-env@github_workflow_analysis
+        uses: genesislcap/appdev-workflows/read-dot-env@github_workflow_analyis
         with:
           config-path: ${{ inputs.config-path }}
 
@@ -254,7 +254,7 @@ jobs:
       # on disk and completes as UP-TO-DATE, avoiding a second full compilation.
       - name: Scan artifact
         if: inputs.jfrogscan
-        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analysis
+        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analyis
         with:
           version: ${{ env.RELEASE_VERSION }}
           jfrog-username: ${{ secrets.JFROG_USERNAME }}

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -292,6 +292,7 @@ jobs:
           working-directory: ${{ inputs.working-directory }}
           server-path: "${{ inputs.working-directory }}/server"
           app-name: ${{ inputs.product_name }}
+          enable-pr-cache: ${{ inputs.enable-pr-cache }}
           build-server-arguments: >-
             ${{ env.CACHE_OPTS }}
             -PpushToCache=${{ env.PR_CACHE_SCOPE == '' && ((github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache)) || false }}

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -45,8 +45,8 @@ on:
       enable-pr-cache:
         type: boolean
         description: >-
-          PR builds only. When true, scopes Gradle and dist-zip cache per client repo and PR
-          (GitHub Actions cache, isolated GRADLE_USER_HOME, dist restore before Scan, optional Artifactory remote when use-artifactory-cache is true).
+          PR builds only. When true, scopes Gradle cache per client repo and PR
+          (GitHub Actions cache + isolated GRADLE_USER_HOME + --build-cache).
           No effect on push/tag.
         default: false
         required: false
@@ -132,10 +132,8 @@ env:
   DISTRIBUTION_DIR: ${{ inputs.distribution_dir || format('{0}-distribution', inputs.product_name) }}
   CACHE_OPTS: ${{ (github.event_name != 'pull_request' || !inputs.enable-pr-cache) && '--no-build-cache --no-configuration-cache' || '--build-cache' }}
   PR_CACHE_SCOPE: ${{ github.event_name == 'pull_request' && inputs.enable-pr-cache && format('{0}-{1}-pr-{2}', github.repository_owner, github.event.repository.name, github.event.pull_request.number) || '' }}
-  GRADLE_PUSH_TO_REMOTE_CACHE: ${{ (github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache) }}
-  GRADLE_DISABLE_REMOTE_CACHE: ${{ !inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache) }}
-  GRADLE_GENESIS_PUSH_TO_CACHE: ${{ (github.event_name != 'pull_request' || !inputs.enable-pr-cache) && ((github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache)) || false }}
-  GRADLE_GENESIS_DISABLE_REMOTE_CACHE: ${{ (github.event_name != 'pull_request' || !inputs.enable-pr-cache) && (!inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache)) }}
+  GRADLE_GENESIS_PUSH_TO_CACHE: ${{ (github.event_name != 'pull_request' || !inputs.enable-pr-cache) && inputs.push-to-artifactory-cache }}
+  GRADLE_GENESIS_DISABLE_REMOTE_CACHE: ${{ (github.event_name == 'pull_request' && inputs.enable-pr-cache) || !inputs.use-artifactory-cache }}
 
 jobs:
   build-server:
@@ -178,43 +176,14 @@ jobs:
       - name: Restore gradle.properties and setup
         env:
           GRADLE_PROPERTIES: ${{ secrets.GRADLE_PROPERTIES }}
-          GENESIS_ARTIFACTORY_USER: ${{ secrets.JFROG_USERNAME }}
-          GENESIS_ARTIFACTORY_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
         working-directory: "${{ inputs.working-directory }}"
         shell: bash
         run: |
           if [ -n "${{ env.PR_CACHE_SCOPE }}" ]; then
             GRADLE_HOME_DIR="${RUNNER_TEMP}/gradle-${{ env.PR_CACHE_SCOPE }}"
-            mkdir -p "${GRADLE_HOME_DIR}/init.d"
+            mkdir -p "${GRADLE_HOME_DIR}"
             echo "GRADLE_USER_HOME=${GRADLE_HOME_DIR}" >> "$GITHUB_ENV"
             echo "PR_CACHE_SCOPE=${{ env.PR_CACHE_SCOPE }}" >> "$GITHUB_ENV"
-            echo "GENESIS_ARTIFACTORY_USER=${GENESIS_ARTIFACTORY_USER}" >> "$GITHUB_ENV"
-            echo "GENESIS_ARTIFACTORY_PASSWORD=${GENESIS_ARTIFACTORY_PASSWORD}" >> "$GITHUB_ENV"
-            echo "GRADLE_PUSH_TO_REMOTE_CACHE=${{ env.GRADLE_PUSH_TO_REMOTE_CACHE }}" >> "$GITHUB_ENV"
-            echo "GRADLE_DISABLE_REMOTE_CACHE=${{ env.GRADLE_DISABLE_REMOTE_CACHE }}" >> "$GITHUB_ENV"
-            cat > "${GRADLE_HOME_DIR}/init.d/pr-cache-remote-scope.init.gradle" << 'INIT_SCRIPT'
-          gradle.beforeSettings { settings ->
-            def scope = System.getenv('PR_CACHE_SCOPE')
-            if (scope == null || scope.isEmpty()) {
-              return
-            }
-            def pushToCache = System.getenv('GRADLE_PUSH_TO_REMOTE_CACHE') == 'true'
-            def user = System.getenv('GENESIS_ARTIFACTORY_USER')
-            def password = System.getenv('GENESIS_ARTIFACTORY_PASSWORD')
-            settings.buildCache {
-              local { enabled = true }
-              remote(org.gradle.caching.http.HttpBuildCache) {
-                url = uri("https://genesisglobal.jfrog.io/genesisglobal/gradle-cache-repo/${scope}/")
-                credentials {
-                  username = user
-                  password = password
-                }
-                push = pushToCache
-                enabled = true
-              }
-            }
-          }
-          INIT_SCRIPT
             echo "Using PR-isolated GRADLE_USER_HOME: ${GRADLE_HOME_DIR}"
           else
             mkdir -p "${HOME}/.gradle"

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -45,8 +45,8 @@ on:
       enable-pr-cache:
         type: boolean
         description: >-
-          PR builds only. When true (and use-artifactory-cache is true), enables Gradle build
-          cache scoped per client repo and PR (GitHub Actions cache, GRADLE_USER_HOME, Artifactory remote).
+          PR builds only. When true, scopes Gradle build cache per client repo and PR
+          (GitHub Actions cache, isolated GRADLE_USER_HOME, optional Artifactory remote when use-artifactory-cache is true).
           No effect on push/tag.
         default: false
         required: false
@@ -147,12 +147,6 @@ jobs:
         with:
           fetch-depth: '0'
           ref: ${{ inputs.branch }}
-
-      - name: Set PR server source hash
-        if: env.PR_CACHE_SCOPE != ''
-        env:
-          PR_SERVER_HASH: ${{ hashFiles(format('{0}/server/**/*.kt', inputs.working-directory), format('{0}/server/**/*.java', inputs.working-directory), format('{0}/server/**/*.kts', inputs.working-directory), format('{0}/server/**/build.gradle.kts', inputs.working-directory), format('{0}/server/**/build.gradle', inputs.working-directory)) }}
-        run: echo "PR_SERVER_HASH=${PR_SERVER_HASH}" >> "$GITHUB_ENV"
 
       - name: Set up JDK
         uses: actions/setup-java@v2
@@ -267,19 +261,9 @@ jobs:
           path: |
             ${{ env.GRADLE_USER_HOME }}/caches
             ${{ env.GRADLE_USER_HOME }}/wrapper
-          key: ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-${{ env.PR_SERVER_HASH }}-${{ hashFiles(format('{0}/gradle.properties', inputs.working-directory), format('{0}/**/gradle-wrapper.properties', inputs.working-directory), format('{0}/server/gradle.properties', inputs.working-directory), format('{0}/server/**/gradle-wrapper.properties', inputs.working-directory)) }}
+          key: ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-${{ hashFiles(format('{0}/gradle.properties', inputs.working-directory), format('{0}/**/gradle-wrapper.properties', inputs.working-directory), format('{0}/server/gradle.properties', inputs.working-directory), format('{0}/server/**/gradle-wrapper.properties', inputs.working-directory)) }}
           restore-keys: |
-            ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-${{ env.PR_SERVER_HASH }}-
             ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-
-
-      # Exact key on server sources only (no restore-keys) so scan reuses dist when code unchanged.
-      - name: Restore dist zip cache (PR-scoped)
-        if: env.PR_CACHE_SCOPE != ''
-        id: pr-dist-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ inputs.working-directory }}/server/*/build/dist
-          key: ${{ runner.os }}-dist-${{ env.PR_CACHE_SCOPE }}-${{ env.PR_SERVER_HASH }}
 
       - name: 'Create .npmrc'
         shell: bash
@@ -319,21 +303,6 @@ jobs:
             -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }}
             ${{ inputs.server-build-gradle-arguments }}
 
-      - name: Warm compile cache when dist zip reused (PR-scoped)
-        if: env.PR_CACHE_SCOPE != '' && steps.pr-dist-cache.outputs.cache-hit == 'true'
-        working-directory: "${{ inputs.working-directory }}/server"
-        shell: bash
-        run: |
-          ./gradlew classes compileTestKotlin \
-            -Pversion=${{ env.RELEASE_VERSION }} \
-            -PgenesisArtifactoryUser="${{ secrets.JFROG_USERNAME }}" \
-            -PgenesisArtifactoryPassword="${{ secrets.JFROG_PASSWORD }}" \
-            -PpushToCache=false \
-            -PdisableRemoteCache=false \
-            ${{ env.CACHE_OPTS }} \
-            --build-cache \
-            ${{ inputs.server-build-gradle-arguments }}
-
       - name: Install Bearer CLI
         if: inputs.sast
         working-directory: "${{ inputs.working-directory }}"
@@ -364,7 +333,7 @@ jobs:
         with:
           arguments: build ${{ env.CACHE_OPTS }} --stacktrace -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ env.GRADLE_GENESIS_PUSH_TO_CACHE }} -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }} ${{ inputs.server-build-gradle-arguments }}
           build-root-directory: "${{ inputs.working-directory }}"
-          cache-disabled: ${{ github.event_name != 'pull_request' || !inputs.enable-pr-cache }}
+          cache-disabled: ${{ env.PR_CACHE_SCOPE != '' || github.event_name != 'pull_request' || !inputs.enable-pr-cache }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
@@ -431,13 +400,6 @@ jobs:
             ./**/build/test-results/**/*.xml
           fail_on: nothing
           report_suite_logs: any
-
-      - name: Save dist zip cache (PR-scoped)
-        if: always() && env.PR_CACHE_SCOPE != ''
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ inputs.working-directory }}/server/*/build/dist
-          key: ${{ runner.os }}-dist-${{ env.PR_CACHE_SCOPE }}-${{ env.PR_SERVER_HASH }}
 
       - name: Save Gradle cache (PR-scoped)
         if: always() && env.PR_CACHE_SCOPE != ''

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -114,6 +114,9 @@ on:
       SENTRY_AUTH_TOKEN:
         required: false
 
+concurrency:
+  group: build-${{ github.repository }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   NODE_AUTH_TOKEN: ${{secrets.GPR_READ_TOKEN}}
@@ -137,13 +140,13 @@ jobs:
 
       - name: Configure Node  ${{ inputs.node_version }}
         if: ${{ !inputs.REGISTRY_URL  }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node_version }}
 
       - name: Configure Node  ${{ inputs.node_version }} if using JFROG npm packages
         if: ${{ inputs.REGISTRY_URL }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node_version }}
           registry-url: ${{ inputs.REGISTRY_URL }}
@@ -216,6 +219,17 @@ jobs:
         with:
           config-path: ${{ inputs.config-path }}
 
+      - name: Scan artifact
+        if: inputs.jfrogscan
+        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analyis
+        with:
+          version: ${{ env.RELEASE_VERSION }}
+          jfrog-username: ${{ secrets.JFROG_USERNAME }}
+          jfrog-password: ${{ secrets.JFROG_PASSWORD }}
+          working-directory: ${{ inputs.working-directory }}
+          server-path: "${{ inputs.working-directory }}/server"
+          app-name: ${{ inputs.product_name }}
+
       - name: Install Bearer CLI
         if: inputs.sast
         working-directory: "${{ inputs.working-directory }}"
@@ -241,7 +255,7 @@ jobs:
           name: sast-report-${{ inputs.product_name }}-${{ github.run_number }}
           path: sast-report-${{ inputs.product_name }}-${{ github.run_number }}.sarif
 
-      - name: Build
+      - name: Build        
         uses: gradle/gradle-build-action@v2
         with:
           arguments: build --no-build-cache --no-configuration-cache --stacktrace -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }} ${{ inputs.server-build-gradle-arguments }}
@@ -249,19 +263,6 @@ jobs:
           cache-disabled: true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-
-      # Runs after build so appDistZip reuses compiled outputs (UP-TO-DATE) instead of rebuilding.
-      - name: Scan artifact
-        if: inputs.jfrogscan
-        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analyis
-        with:
-          version: ${{ env.RELEASE_VERSION }}
-          jfrog-username: ${{ secrets.JFROG_USERNAME }}
-          jfrog-password: ${{ secrets.JFROG_PASSWORD }}
-          working-directory: ${{ inputs.working-directory }}
-          server-path: server
-          app-name: ${{ inputs.product_name }}
-          build-server-arguments: ${{ inputs.server-build-gradle-arguments }}
 
       - name: Test and Coverage
         if: inputs.sonar_enabled

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -230,7 +230,7 @@ jobs:
 
       - name: Scan artifact
         if: inputs.jfrogscan
-        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@develop
+        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analyis
         with:
           version: ${{ env.RELEASE_VERSION }}
           jfrog-username: ${{ secrets.JFROG_USERNAME }}
@@ -238,6 +238,12 @@ jobs:
           working-directory: ${{ inputs.working-directory }}
           server-path: "${{ inputs.working-directory }}/server"
           app-name: ${{ inputs.product_name }}
+          gradle-cache-enabled: ${{ github.event_name == 'pull_request' && inputs.enable-pr-cache }}
+          build-server-arguments: >-
+            ${{ env.CACHE_OPTS }}
+            -PpushToCache=${{ (github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache) }}
+            -PdisableRemoteCache=${{ !inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache) }}
+            ${{ inputs.server-build-gradle-arguments }}
 
       - name: Install Bearer CLI
         if: inputs.sast

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -124,26 +124,26 @@ jobs:
   build-server:
     runs-on: [ appdev-selfhosted-al2023 ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
           ref: ${{ inputs.branch }}
 
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ inputs.java_version }}
           distribution: 'adopt'
 
       - name: Configure Node  ${{ inputs.node_version }}
         if: ${{ !inputs.REGISTRY_URL  }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node_version }}
 
       - name: Configure Node  ${{ inputs.node_version }} if using JFROG npm packages
         if: ${{ inputs.REGISTRY_URL }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node_version }}
           registry-url: ${{ inputs.REGISTRY_URL }}
@@ -212,20 +212,9 @@ jobs:
 
       - name: Read .env file for build
         if: ${{ inputs.config-path }}
-        uses: genesislcap/appdev-workflows/read-dot-env@develop
+        uses: genesislcap/appdev-workflows/read-dot-env@github_workflow_analysis
         with:
           config-path: ${{ inputs.config-path }}
-
-      - name: Scan artifact
-        if: inputs.jfrogscan
-        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@develop
-        with:
-          version: ${{ env.RELEASE_VERSION }}
-          jfrog-username: ${{ secrets.JFROG_USERNAME }}
-          jfrog-password: ${{ secrets.JFROG_PASSWORD }}
-          working-directory: ${{ inputs.working-directory }}
-          server-path: "${{ inputs.working-directory }}/server"
-          app-name: ${{ inputs.product_name }}
 
       - name: Install Bearer CLI
         if: inputs.sast
@@ -259,8 +248,20 @@ jobs:
           build-root-directory: "${{ inputs.working-directory }}"
           cache-disabled: true
         env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}     
-      
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      # Runs after the build so Gradle's appDistZip task finds its outputs already
+      # on disk and completes as UP-TO-DATE, avoiding a second full compilation.
+      - name: Scan artifact
+        if: inputs.jfrogscan
+        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analysis
+        with:
+          version: ${{ env.RELEASE_VERSION }}
+          jfrog-username: ${{ secrets.JFROG_USERNAME }}
+          jfrog-password: ${{ secrets.JFROG_PASSWORD }}
+          working-directory: ${{ inputs.working-directory }}
+          server-path: "${{ inputs.working-directory }}/server"
+          app-name: ${{ inputs.product_name }}
 
       - name: Test and Coverage
         if: inputs.sonar_enabled

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -250,6 +250,7 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
+      # Runs after Build so appDistZip reuses compiled outputs (UP-TO-DATE) instead of a second full build.
       - name: Scan artifact
         if: inputs.jfrogscan
         uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analyis
@@ -258,7 +259,8 @@ jobs:
           jfrog-username: ${{ secrets.JFROG_USERNAME }}
           jfrog-password: ${{ secrets.JFROG_PASSWORD }}
           working-directory: ${{ inputs.working-directory }}
-          server-path: "${{ inputs.working-directory }}/server"
+          server-path: server
+          build-server-arguments: ${{ inputs.server-build-gradle-arguments }}
           app-name: ${{ inputs.product_name }}
 
       - name: Test and Coverage

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -42,6 +42,31 @@ on:
         description: Push to the Artifactory cache
         default: false
         required: false
+      cache-read-only:
+        type: boolean
+        description: Whether the GitHub cache should be read-only
+        default: true
+        required: false
+      cache-write-only:
+        type: boolean
+        description: Whether the GitHub cache should be write-only
+        default: false
+        required: false
+      enable-pr-cache:
+        type: boolean
+        description: Enable caches on pull_request only (GitHub + Gradle; Artifactory when use-artifactory-cache is true)
+        default: false
+        required: false
+      disable-cache:
+        type: boolean
+        description: Deprecated — use enable-pr-cache true instead. When false, also enables PR caches (default true keeps caches off)
+        default: true
+        required: false
+      enable-configuration-cache:
+        type: boolean
+        description: Enable Gradle configuration cache when PR cache is enabled (enable-pr-cache true); validate per repo first
+        default: false
+        required: false
       working-directory:
         type: string
         default: .
@@ -114,13 +139,17 @@ on:
       SENTRY_AUTH_TOKEN:
         required: false
 
+# Caller context: PR number is empty for push/tag/dispatch — never use it alone (see reverted PR #168).
+# Group by PR id when present; otherwise event + ref so tags/releases/develop do not share one group.
 concurrency:
-  group: build-${{ github.repository }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: build-${{ github.repository }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('{0}-{1}', github.event_name, github.ref) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   NODE_AUTH_TOKEN: ${{secrets.GPR_READ_TOKEN}}
   DISTRIBUTION_DIR: ${{ inputs.distribution_dir || format('{0}-distribution', inputs.product_name) }}
+  # PR cache only when caller sets enable-pr-cache true (or disable-cache false)
+  CACHE_OPTS: ${{ (github.event_name != 'pull_request' || (!inputs.enable-pr-cache && inputs.disable-cache)) && '--no-build-cache --no-configuration-cache' || (inputs.enable-configuration-cache && '' || '--no-configuration-cache') }}
 
 # A workflow run is called from the devops appdev-workflow repos
 jobs:
@@ -198,6 +227,14 @@ jobs:
 
           echo "GENX_BUILD_INFO=${{ github.ref_name }} / $(date -u +'%Y-%m-%d-%H%M%S') / $(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-overwrite-existing: true
+          cache-read-only: ${{ github.event_name == 'pull_request' && (inputs.enable-pr-cache || !inputs.disable-cache) }}
+          cache-write-only: false
+          cache-disabled: ${{ github.event_name != 'pull_request' || (!inputs.enable-pr-cache && inputs.disable-cache) }}
+
       - name: 'Create .npmrc'
         shell: bash
         run: |
@@ -255,26 +292,18 @@ jobs:
           name: sast-report-${{ inputs.product_name }}-${{ github.run_number }}
           path: sast-report-${{ inputs.product_name }}-${{ github.run_number }}.sarif
 
-      - name: Build        
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: build --no-build-cache --no-configuration-cache --stacktrace -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }} ${{ inputs.server-build-gradle-arguments }}
-          build-root-directory: "${{ inputs.working-directory }}"
-          cache-disabled: true
+      - name: Build
+        working-directory: "${{ inputs.working-directory }}"
+        run: ./gradlew build --stacktrace -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ github.event_name != 'pull_request' && inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ github.event_name != 'pull_request' || (!inputs.enable-pr-cache && inputs.disable-cache) || !inputs.use-artifactory-cache }} ${{ inputs.server-build-gradle-arguments }} ${{ env.CACHE_OPTS }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Test and Coverage
         if: inputs.sonar_enabled
-        uses: gradle/gradle-build-action@v2
+        working-directory: "${{ inputs.working-directory }}/server"
         env:
           SONAR_TOKEN: ${{ secrets.JENKINSGENESIS_SONAR }}
-        with:
-          arguments: >
-            test jacocoTestReport sonarqube --no-configuration-cache
-            -Dsonar.token=${{ env.SONAR_TOKEN }}
-          build-root-directory: "${{ inputs.working-directory }}/server"
-          cache-disabled: true
+        run: ./gradlew test jacocoTestReport sonarqube --stacktrace -Dsonar.token=${{ env.SONAR_TOKEN }} ${{ env.CACHE_OPTS }}
 
       - name: Check Auth Permissions task
         id: auth_permissions_task
@@ -293,7 +322,7 @@ jobs:
         shell: bash
         working-directory: "${{ inputs.working-directory }}/server"
         run: |
-          ./gradlew checkAuthPermissions --no-configuration-cache --build-cache --stacktrace
+          ./gradlew checkAuthPermissions --stacktrace ${{ env.CACHE_OPTS }}
 
       - name: Upload Genesis security permissions report
         uses: actions/upload-artifact@v4
@@ -322,26 +351,20 @@ jobs:
 
       - name: Docker Build Image
         if: inputs.build_docker
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: :genesisproduct-${{ inputs.product_name }}:${{ inputs.product_name }}-deploy:buildImage
-          build-root-directory: "${{ inputs.working-directory }}/"
-          cache-disabled: true
+        working-directory: "${{ inputs.working-directory }}/"
+        run: ./gradlew :genesisproduct-${{ inputs.product_name }}:${{ inputs.product_name }}-deploy:buildImage ${{ env.CACHE_OPTS }}
 
       - name: Docker Push Image
         if: inputs.build_docker
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: :genesisproduct-${{ inputs.product_name }}:${{ inputs.product_name }}-deploy:pushImage
-          build-root-directory: "${{ inputs.working-directory }}/"
-          cache-disabled: true
+        working-directory: "${{ inputs.working-directory }}/"
+        run: ./gradlew :genesisproduct-${{ inputs.product_name }}:${{ inputs.product_name }}-deploy:pushImage ${{ env.CACHE_OPTS }}
 
       - name: Create Giant Server Zip
         if: inputs.upload
         shell: bash
         working-directory: "${{ inputs.working-directory }}/server"
         run: |
-          ./gradlew tasks -Pversion=${{ env.RELEASE_VERSION }} | grep install- | cut -d " " -f1 | xargs -I{} ./gradlew -Pversion=${{ env.RELEASE_VERSION }} {} ${{ inputs.server-install-gradle-arguments }}
+          ./gradlew tasks -Pversion=${{ env.RELEASE_VERSION }} ${{ env.CACHE_OPTS }} | grep install- | cut -d " " -f1 | xargs -I{} ./gradlew -Pversion=${{ env.RELEASE_VERSION }} {} ${{ inputs.server-install-gradle-arguments }} ${{ env.CACHE_OPTS }}
           cd .genesis-home
           pwd
           ls -la
@@ -365,15 +388,12 @@ jobs:
 
       - name: Artifactory Publish
         if: inputs.publish-to-artifactory
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: artifactoryPublish -x test --no-build-cache --no-configuration-cache -PdeployToClientRepo=false
-          build-root-directory: "${{ inputs.working-directory }}/server"
-          cache-disabled: true
+        working-directory: "${{ inputs.working-directory }}/server"
+        run: ./gradlew artifactoryPublish -x test -PdeployToClientRepo=false ${{ env.CACHE_OPTS }}
 
       - name: Update Jira tickets with fix version
         if: inputs.update-jira
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           repository: genesislcap/appdev-workflows
           path: ./appdev-workflows

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -285,7 +285,7 @@ jobs:
 
       - name: Scan artifact
         if: inputs.jfrogscan
-        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@workflow_jfrog_cache
+        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analyis
         with:
           version: ${{ env.RELEASE_VERSION }}
           jfrog-username: ${{ secrets.JFROG_USERNAME }}
@@ -492,5 +492,3 @@ jobs:
       release-version: ${{ inputs.version }}
     secrets:
       JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
-
-

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -399,7 +399,7 @@ jobs:
           report_suite_logs: any
 
       - name: Save Gradle cache (PR-scoped)
-        if: always() && env.PR_CACHE_SCOPE != ''
+        if: success() && env.PR_CACHE_SCOPE != ''
         uses: actions/cache/save@v4
         with:
           path: |

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -137,13 +137,13 @@ jobs:
 
       - name: Configure Node  ${{ inputs.node_version }}
         if: ${{ !inputs.REGISTRY_URL  }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ inputs.node_version }}
 
       - name: Configure Node  ${{ inputs.node_version }} if using JFROG npm packages
         if: ${{ inputs.REGISTRY_URL }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ inputs.node_version }}
           registry-url: ${{ inputs.REGISTRY_URL }}

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -216,6 +216,17 @@ jobs:
         with:
           config-path: ${{ inputs.config-path }}
 
+      - name: Scan artifact
+        if: inputs.jfrogscan
+        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analyis
+        with:
+          version: ${{ env.RELEASE_VERSION }}
+          jfrog-username: ${{ secrets.JFROG_USERNAME }}
+          jfrog-password: ${{ secrets.JFROG_PASSWORD }}
+          working-directory: ${{ inputs.working-directory }}
+          server-path: "${{ inputs.working-directory }}/server"
+          app-name: ${{ inputs.product_name }}
+
       - name: Install Bearer CLI
         if: inputs.sast
         working-directory: "${{ inputs.working-directory }}"
@@ -250,16 +261,7 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}     
       
-      - name: Scan artifact
-        if: inputs.jfrogscan
-        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analyis
-        with:
-          version: ${{ env.RELEASE_VERSION }}
-          jfrog-username: ${{ secrets.JFROG_USERNAME }}
-          jfrog-password: ${{ secrets.JFROG_PASSWORD }}
-          working-directory: ${{ inputs.working-directory }}
-          server-path: "${{ inputs.working-directory }}/server"
-          app-name: ${{ inputs.product_name }}
+
       - name: Test and Coverage
         if: inputs.sonar_enabled
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -216,16 +216,16 @@ jobs:
         with:
           config-path: ${{ inputs.config-path }}
 
-#      - name: Scan artifact
-#        if: inputs.jfrogscan
-#        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analyis
-#        with:
-#          version: ${{ env.RELEASE_VERSION }}
-#          jfrog-username: ${{ secrets.JFROG_USERNAME }}
-#          jfrog-password: ${{ secrets.JFROG_PASSWORD }}
-#          working-directory: ${{ inputs.working-directory }}
-#          server-path: "${{ inputs.working-directory }}/server"
-#          app-name: ${{ inputs.product_name }}
+      - name: Scan artifact
+        if: inputs.jfrogscan
+        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analyis
+        with:
+          version: ${{ env.RELEASE_VERSION }}
+          jfrog-username: ${{ secrets.JFROG_USERNAME }}
+          jfrog-password: ${{ secrets.JFROG_PASSWORD }}
+          working-directory: ${{ inputs.working-directory }}
+          server-path: "${{ inputs.working-directory }}/server"
+          app-name: ${{ inputs.product_name }}
 
       - name: Install Bearer CLI
         if: inputs.sast

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -125,7 +125,7 @@ on:
 # PR number is only set on pull_request; else for push/tag use event + ref
 concurrency:
   group: build-${{ github.repository }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('{0}-{1}', github.event_name, github.ref) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' && !inputs.enable-pr-cache }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && inputs.enable-pr-cache }}
 
 env:
   NODE_AUTH_TOKEN: ${{secrets.GPR_READ_TOKEN}}
@@ -285,7 +285,7 @@ jobs:
 
       - name: Scan artifact
         if: inputs.jfrogscan
-        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analyis
+        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@develop
         with:
           version: ${{ env.RELEASE_VERSION }}
           jfrog-username: ${{ secrets.JFROG_USERNAME }}

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -130,7 +130,7 @@ jobs:
           ref: ${{ inputs.branch }}
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v2
         with:
           java-version: ${{ inputs.java_version }}
           distribution: 'adopt'

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -46,7 +46,8 @@ on:
         type: boolean
         description: >-
           PR builds only. When true (and use-artifactory-cache is true), enables Gradle build
-          cache and Artifactory remote cache for pull_request events. No effect on push/tag.
+          cache scoped per client repo and PR (GitHub Actions cache, GRADLE_USER_HOME, Artifactory remote).
+          No effect on push/tag.
         default: false
         required: false
       working-directory:
@@ -130,6 +131,9 @@ env:
   NODE_AUTH_TOKEN: ${{secrets.GPR_READ_TOKEN}}
   DISTRIBUTION_DIR: ${{ inputs.distribution_dir || format('{0}-distribution', inputs.product_name) }}
   CACHE_OPTS: ${{ (github.event_name != 'pull_request' || !inputs.enable-pr-cache) && '--no-build-cache --no-configuration-cache' || '' }}
+  PR_CACHE_SCOPE: ${{ github.event_name == 'pull_request' && inputs.enable-pr-cache && format('{0}-{1}-pr-{2}', github.repository_owner, github.event.repository.name, github.event.pull_request.number) || '' }}
+  GRADLE_PUSH_TO_REMOTE_CACHE: ${{ (github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache) }}
+  GRADLE_DISABLE_REMOTE_CACHE: ${{ !inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache) }}
 
 # A workflow run is called from the devops appdev-workflow repos
 jobs:
@@ -173,29 +177,69 @@ jobs:
       - name: Restore gradle.properties and setup
         env:
           GRADLE_PROPERTIES: ${{ secrets.GRADLE_PROPERTIES }}
+          GENESIS_ARTIFACTORY_USER: ${{ secrets.JFROG_USERNAME }}
+          GENESIS_ARTIFACTORY_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
         working-directory: "${{ inputs.working-directory }}"
         shell: bash
         run: |
-          mkdir -p ~/.gradle/
-          echo "GRADLE_USER_HOME=${HOME}/.gradle" >> $GITHUB_ENV
-          echo "genesisArtifactoryUser=${{ secrets.JFROG_USERNAME }}" > ~/.gradle/gradle.properties
-          echo "genesisArtifactoryPassword=${{ secrets.JFROG_PASSWORD }}" >> ~/.gradle/gradle.properties
+          if [ -n "${{ env.PR_CACHE_SCOPE }}" ]; then
+            GRADLE_HOME_DIR="${RUNNER_TEMP}/gradle-${{ env.PR_CACHE_SCOPE }}"
+            mkdir -p "${GRADLE_HOME_DIR}/init.d"
+            echo "GRADLE_USER_HOME=${GRADLE_HOME_DIR}" >> "$GITHUB_ENV"
+            echo "PR_CACHE_SCOPE=${{ env.PR_CACHE_SCOPE }}" >> "$GITHUB_ENV"
+            echo "GENESIS_ARTIFACTORY_USER=${GENESIS_ARTIFACTORY_USER}" >> "$GITHUB_ENV"
+            echo "GENESIS_ARTIFACTORY_PASSWORD=${GENESIS_ARTIFACTORY_PASSWORD}" >> "$GITHUB_ENV"
+            echo "GRADLE_PUSH_TO_REMOTE_CACHE=${{ env.GRADLE_PUSH_TO_REMOTE_CACHE }}" >> "$GITHUB_ENV"
+            echo "GRADLE_DISABLE_REMOTE_CACHE=${{ env.GRADLE_DISABLE_REMOTE_CACHE }}" >> "$GITHUB_ENV"
+            cat > "${GRADLE_HOME_DIR}/init.d/pr-cache-remote-scope.init.gradle" << 'INIT_SCRIPT'
+          gradle.beforeSettings { settings ->
+            def scope = System.getenv('PR_CACHE_SCOPE')
+            if (scope == null || scope.isEmpty()) {
+              return
+            }
+            def pushToCache = System.getenv('GRADLE_PUSH_TO_REMOTE_CACHE') == 'true'
+            def disableRemote = System.getenv('GRADLE_DISABLE_REMOTE_CACHE') == 'true'
+            def user = System.getenv('GENESIS_ARTIFACTORY_USER')
+            def password = System.getenv('GENESIS_ARTIFACTORY_PASSWORD')
+            settings.buildCache {
+              local { enabled = true }
+              remote(org.gradle.caching.http.HttpBuildCache) {
+                url = uri("https://genesisglobal.jfrog.io/genesisglobal/gradle-cache-repo/${scope}/")
+                credentials {
+                  username = user
+                  password = password
+                }
+                push = pushToCache
+                enabled = !disableRemote
+              }
+            }
+          }
+          INIT_SCRIPT
+            echo "Using PR-isolated GRADLE_USER_HOME: ${GRADLE_HOME_DIR}"
+          else
+            mkdir -p "${HOME}/.gradle"
+            GRADLE_HOME_DIR="${HOME}/.gradle"
+            echo "GRADLE_USER_HOME=${GRADLE_HOME_DIR}" >> "$GITHUB_ENV"
+          fi
 
-          echo "systemProp.org.gradle.internal.http.connectionTimeout=180000" >> ~/.gradle/gradle.properties
-          echo "systemProp.org.gradle.internal.http.socketTimeout=180000" >> ~/.gradle/gradle.properties
+          echo "genesisArtifactoryUser=${{ secrets.JFROG_USERNAME }}" > "${GRADLE_HOME_DIR}/gradle.properties"
+          echo "genesisArtifactoryPassword=${{ secrets.JFROG_PASSWORD }}" >> "${GRADLE_HOME_DIR}/gradle.properties"
 
-          echo "dockerUrl=genesisglobal-docker-internal.jfrog.io" >> ~/.gradle/gradle.properties
-          echo "dockerUsername=${{ secrets.JFROG_USERNAME }}" >> ~/.gradle/gradle.properties
-          echo "dockerPassword=${{ secrets.JFROG_PASSWORD }}" >> ~/.gradle/gradle.properties
-          echo "dockerEmail=platformmanageteam@genesis.global" >> ~/.gradle/gradle.properties
+          echo "systemProp.org.gradle.internal.http.connectionTimeout=180000" >> "${GRADLE_HOME_DIR}/gradle.properties"
+          echo "systemProp.org.gradle.internal.http.socketTimeout=180000" >> "${GRADLE_HOME_DIR}/gradle.properties"
 
-          echo "genesis-home=../.genesis-home" >> ~/.gradle/gradle.properties
-          echo "deploy-plugin-mode=local" >> ~/.gradle/gradle.properties
-          echo "genesis.check.permission.enabled=true" >> ~/.gradle/gradle.properties
+          echo "dockerUrl=genesisglobal-docker-internal.jfrog.io" >> "${GRADLE_HOME_DIR}/gradle.properties"
+          echo "dockerUsername=${{ secrets.JFROG_USERNAME }}" >> "${GRADLE_HOME_DIR}/gradle.properties"
+          echo "dockerPassword=${{ secrets.JFROG_PASSWORD }}" >> "${GRADLE_HOME_DIR}/gradle.properties"
+          echo "dockerEmail=platformmanageteam@genesis.global" >> "${GRADLE_HOME_DIR}/gradle.properties"
+
+          echo "genesis-home=../.genesis-home" >> "${GRADLE_HOME_DIR}/gradle.properties"
+          echo "deploy-plugin-mode=local" >> "${GRADLE_HOME_DIR}/gradle.properties"
+          echo "genesis.check.permission.enabled=true" >> "${GRADLE_HOME_DIR}/gradle.properties"
           sudo chmod +x ./gradlew
           sudo chmod +x ./server/gradlew
 
-          cat ~/.gradle/gradle.properties >>  ./gradle.properties
+          cat "${GRADLE_HOME_DIR}/gradle.properties" >> ./gradle.properties
           if [ -z "${{ inputs.repo-name }}" ]; then
             echo "REPO_NAME=$(echo '${{ github.event.repository.name }}' | cut -d'-' -f1)" >> $GITHUB_ENV
           else
@@ -206,6 +250,17 @@ jobs:
           sed -E -i "s/^\s{4}version = \".+\"/    version = \"${RELEASE_VERSION}\"/g" server/build.gradle.kts
 
           echo "GENX_BUILD_INFO=${{ github.ref_name }} / $(date -u +'%Y-%m-%d-%H%M%S') / $(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Restore Gradle cache (PR-scoped)
+        if: env.PR_CACHE_SCOPE != ''
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ env.GRADLE_USER_HOME }}/caches
+            ${{ env.GRADLE_USER_HOME }}/wrapper
+          key: ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-${{ hashFiles(format('{0}/gradle.properties', inputs.working-directory), format('{0}/**/gradle-wrapper.properties', inputs.working-directory), format('{0}/server/gradle.properties', inputs.working-directory), format('{0}/server/**/gradle-wrapper.properties', inputs.working-directory)) }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-
 
       - name: 'Create .npmrc'
         shell: bash
@@ -274,7 +329,7 @@ jobs:
         with:
           arguments: build ${{ env.CACHE_OPTS }} --stacktrace -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ (github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache) }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache) }} ${{ inputs.server-build-gradle-arguments }}
           build-root-directory: "${{ inputs.working-directory }}"
-          cache-disabled: ${{ github.event_name != 'pull_request' || !inputs.enable-pr-cache }}
+          cache-disabled: ${{ env.PR_CACHE_SCOPE != '' || github.event_name != 'pull_request' || !inputs.enable-pr-cache }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -130,7 +130,7 @@ concurrency:
 env:
   NODE_AUTH_TOKEN: ${{secrets.GPR_READ_TOKEN}}
   DISTRIBUTION_DIR: ${{ inputs.distribution_dir || format('{0}-distribution', inputs.product_name) }}
-  CACHE_OPTS: ${{ (github.event_name != 'pull_request' || !inputs.enable-pr-cache) && '--no-build-cache --no-configuration-cache' || '' }}
+  CACHE_OPTS: ${{ (github.event_name != 'pull_request' || !inputs.enable-pr-cache) && '--no-build-cache --no-configuration-cache' || '--build-cache' }}
   PR_CACHE_SCOPE: ${{ github.event_name == 'pull_request' && inputs.enable-pr-cache && format('{0}-{1}-pr-{2}', github.repository_owner, github.event.repository.name, github.event.pull_request.number) || '' }}
   GRADLE_PUSH_TO_REMOTE_CACHE: ${{ (github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache) }}
   GRADLE_DISABLE_REMOTE_CACHE: ${{ !inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache) }}
@@ -145,14 +145,6 @@ jobs:
         with:
           fetch-depth: '0'
           ref: ${{ inputs.branch }}
-
-      - name: Set dist cache input hash
-        if: env.PR_CACHE_SCOPE != ''
-        working-directory: "${{ inputs.working-directory }}"
-        shell: bash
-        run: |
-          HASH=$( (git ls-files -z server; git ls-files -z client 2>/dev/null || true) | sort -zu | git hash-object --stdin)
-          echo "DIST_INPUT_HASH=${HASH}" >> "$GITHUB_ENV"
 
       - name: Set up JDK
         uses: actions/setup-java@v2
@@ -261,23 +253,14 @@ jobs:
 
       - name: Restore Gradle cache (PR-scoped)
         if: env.PR_CACHE_SCOPE != ''
-        id: pr-gradle-cache
         uses: actions/cache/restore@v4
         with:
           path: |
             ${{ env.GRADLE_USER_HOME }}/caches
             ${{ env.GRADLE_USER_HOME }}/wrapper
-          key: ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-${{ hashFiles(format('{0}/gradle.properties', inputs.working-directory), format('{0}/**/gradle-wrapper.properties', inputs.working-directory), format('{0}/server/gradle.properties', inputs.working-directory), format('{0}/server/**/gradle-wrapper.properties', inputs.working-directory)) }}
+          key: ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-${{ github.run_id }}
           restore-keys: |
             ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-
-
-      - name: Restore dist zip cache (PR-scoped)
-        if: env.PR_CACHE_SCOPE != ''
-        id: pr-dist-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ inputs.working-directory }}/server/*/build/dist
-          key: ${{ runner.os }}-dist-${{ env.PR_CACHE_SCOPE }}-${{ env.DIST_INPUT_HASH }}
 
       - name: 'Create .npmrc'
         shell: bash
@@ -315,26 +298,6 @@ jobs:
             ${{ env.CACHE_OPTS }}
             -PpushToCache=${{ env.GRADLE_GENESIS_PUSH_TO_CACHE }}
             -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }}
-            ${{ inputs.server-build-gradle-arguments }}
-
-      # Scan skips appDistZip when the dist zip was restored from GHA. May 29 still ran
-      # appDistZip in the same job before Build, which let pbi-app:test be FROM-CACHE (~30s).
-      # Re-run appDistZip here (usually UP-TO-DATE when the zip is already on disk) so Build
-      # does not execute a full pbi-app:test (~12m). Do not use warm compileTestKotlin — it
-      # recompiles test sources and forces tests to run again.
-      - name: Prime Gradle via appDistZip when dist zip restored (PR-scoped)
-        if: env.PR_CACHE_SCOPE != '' && steps.pr-dist-cache.outputs.cache-hit == 'true'
-        working-directory: "${{ inputs.working-directory }}/server"
-        shell: bash
-        run: |
-          ./gradlew appDistZip \
-            -Pversion=${{ env.RELEASE_VERSION }} \
-            -PgenesisArtifactoryUser="${{ secrets.JFROG_USERNAME }}" \
-            -PgenesisArtifactoryPassword="${{ secrets.JFROG_PASSWORD }}" \
-            -PpushToCache=false \
-            -PdisableRemoteCache=false \
-            ${{ env.CACHE_OPTS }} \
-            --build-cache \
             ${{ inputs.server-build-gradle-arguments }}
 
       - name: Install Bearer CLI
@@ -401,7 +364,7 @@ jobs:
         shell: bash
         working-directory: "${{ inputs.working-directory }}/server"
         run: |
-          ./gradlew checkAuthPermissions --no-configuration-cache --build-cache --stacktrace
+          ./gradlew checkAuthPermissions --no-configuration-cache ${{ env.CACHE_OPTS }} --stacktrace
 
       - name: Upload Genesis security permissions report
         uses: actions/upload-artifact@v4
@@ -435,13 +398,6 @@ jobs:
           fail_on: nothing
           report_suite_logs: any
 
-      - name: Save dist zip cache (PR-scoped)
-        if: always() && env.PR_CACHE_SCOPE != ''
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ inputs.working-directory }}/server/*/build/dist
-          key: ${{ runner.os }}-dist-${{ env.PR_CACHE_SCOPE }}-${{ env.DIST_INPUT_HASH }}
-
       - name: Save Gradle cache (PR-scoped)
         if: always() && env.PR_CACHE_SCOPE != ''
         uses: actions/cache/save@v4
@@ -449,7 +405,7 @@ jobs:
           path: |
             ${{ env.GRADLE_USER_HOME }}/caches
             ${{ env.GRADLE_USER_HOME }}/wrapper
-          key: ${{ steps.pr-gradle-cache.outputs.cache-primary-key }}
+          key: ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-${{ github.run_id }}
 
       - name: Docker Build Image
         if: inputs.build_docker

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -124,7 +124,7 @@ jobs:
   build-server:
     runs-on: [ appdev-selfhosted-al2023 ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
           ref: ${{ inputs.branch }}

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -122,7 +122,7 @@ env:
 # A workflow run is called from the devops appdev-workflow repos
 jobs:
   build-server:
-    runs-on: [ self-hosted, selfhosted-services ]
+    runs-on: [ appdev-selfhosted-al2023 ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -216,17 +216,6 @@ jobs:
         with:
           config-path: ${{ inputs.config-path }}
 
-      - name: Scan artifact
-        if: inputs.jfrogscan
-        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analyis
-        with:
-          version: ${{ env.RELEASE_VERSION }}
-          jfrog-username: ${{ secrets.JFROG_USERNAME }}
-          jfrog-password: ${{ secrets.JFROG_PASSWORD }}
-          working-directory: ${{ inputs.working-directory }}
-          server-path: "${{ inputs.working-directory }}/server"
-          app-name: ${{ inputs.product_name }}
-
       - name: Install Bearer CLI
         if: inputs.sast
         working-directory: "${{ inputs.working-directory }}"
@@ -252,14 +241,25 @@ jobs:
           name: sast-report-${{ inputs.product_name }}-${{ github.run_number }}
           path: sast-report-${{ inputs.product_name }}-${{ github.run_number }}.sarif
 
-      - name: Build        
+      - name: Build
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build --no-build-cache --no-configuration-cache --stacktrace -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }} ${{ inputs.server-build-gradle-arguments }}
+          arguments: build --no-build-cache --no-configuration-cache --stacktrace --refresh-dependencies -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=false ${{ inputs.server-build-gradle-arguments }}
           build-root-directory: "${{ inputs.working-directory }}"
           cache-disabled: true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: Scan artifact
+        if: inputs.jfrogscan
+        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analyis
+        with:
+          version: ${{ env.RELEASE_VERSION }}
+          jfrog-username: ${{ secrets.JFROG_USERNAME }}
+          jfrog-password: ${{ secrets.JFROG_PASSWORD }}
+          working-directory: ${{ inputs.working-directory }}
+          server-path: "${{ inputs.working-directory }}/server"
+          app-name: ${{ inputs.product_name }}
 
       - name: Test and Coverage
         if: inputs.sonar_enabled

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -198,7 +198,6 @@ jobs:
               return
             }
             def pushToCache = System.getenv('GRADLE_PUSH_TO_REMOTE_CACHE') == 'true'
-            def disableRemote = System.getenv('GRADLE_DISABLE_REMOTE_CACHE') == 'true'
             def user = System.getenv('GENESIS_ARTIFACTORY_USER')
             def password = System.getenv('GENESIS_ARTIFACTORY_PASSWORD')
             settings.buildCache {
@@ -210,7 +209,7 @@ jobs:
                   password = password
                 }
                 push = pushToCache
-                enabled = !disableRemote
+                enabled = true
               }
             }
           }
@@ -295,8 +294,8 @@ jobs:
           app-name: ${{ inputs.product_name }}
           build-server-arguments: >-
             ${{ env.CACHE_OPTS }}
-            -PpushToCache=${{ (github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache) }}
-            -PdisableRemoteCache=${{ !inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache) }}
+            -PpushToCache=${{ env.PR_CACHE_SCOPE == '' && ((github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache)) || false }}
+            -PdisableRemoteCache=${{ env.PR_CACHE_SCOPE != '' && true || (!inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache)) }}
             ${{ inputs.server-build-gradle-arguments }}
 
       - name: Install Bearer CLI
@@ -327,9 +326,9 @@ jobs:
       - name: Build
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build ${{ env.CACHE_OPTS }} --stacktrace -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ (github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache) }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache) }} ${{ inputs.server-build-gradle-arguments }}
+          arguments: build ${{ env.CACHE_OPTS }} --stacktrace -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ env.PR_CACHE_SCOPE == '' && ((github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache)) || false }} -PdisableRemoteCache=${{ env.PR_CACHE_SCOPE != '' && true || (!inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache)) }} ${{ inputs.server-build-gradle-arguments }}
           build-root-directory: "${{ inputs.working-directory }}"
-          cache-disabled: ${{ env.PR_CACHE_SCOPE != '' || github.event_name != 'pull_request' || !inputs.enable-pr-cache }}
+          cache-disabled: ${{ github.event_name != 'pull_request' || !inputs.enable-pr-cache }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -238,7 +238,6 @@ jobs:
           working-directory: ${{ inputs.working-directory }}
           server-path: "${{ inputs.working-directory }}/server"
           app-name: ${{ inputs.product_name }}
-          gradle-cache-enabled: ${{ github.event_name == 'pull_request' && inputs.enable-pr-cache }}
           build-server-arguments: >-
             ${{ env.CACHE_OPTS }}
             -PpushToCache=${{ (github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache) }}

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -216,17 +216,6 @@ jobs:
         with:
           config-path: ${{ inputs.config-path }}
 
-      - name: Scan artifact
-        if: inputs.jfrogscan
-        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analyis
-        with:
-          version: ${{ env.RELEASE_VERSION }}
-          jfrog-username: ${{ secrets.JFROG_USERNAME }}
-          jfrog-password: ${{ secrets.JFROG_PASSWORD }}
-          working-directory: ${{ inputs.working-directory }}
-          server-path: "${{ inputs.working-directory }}/server"
-          app-name: ${{ inputs.product_name }}
-
       - name: Install Bearer CLI
         if: inputs.sast
         working-directory: "${{ inputs.working-directory }}"
@@ -261,6 +250,18 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
+      # Runs after build so appDistZip reuses compiled outputs (UP-TO-DATE) instead of rebuilding.
+      - name: Scan artifact
+        if: inputs.jfrogscan
+        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analyis
+        with:
+          version: ${{ env.RELEASE_VERSION }}
+          jfrog-username: ${{ secrets.JFROG_USERNAME }}
+          jfrog-password: ${{ secrets.JFROG_PASSWORD }}
+          working-directory: ${{ inputs.working-directory }}
+          server-path: server
+          app-name: ${{ inputs.product_name }}
+          build-server-arguments: ${{ inputs.server-build-gradle-arguments }}
 
       - name: Test and Coverage
         if: inputs.sonar_enabled

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -122,7 +122,7 @@ on:
       SENTRY_AUTH_TOKEN:
         required: false
 
-# PR number is only set on pull_request; for push/tag use event + ref (see reverted PR #168).
+# PR number is only set on pull_request; else for push/tag use event + ref
 concurrency:
   group: build-${{ github.repository }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('{0}-{1}', github.event_name, github.ref) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' && !inputs.enable-pr-cache }}
@@ -134,11 +134,9 @@ env:
   PR_CACHE_SCOPE: ${{ github.event_name == 'pull_request' && inputs.enable-pr-cache && format('{0}-{1}-pr-{2}', github.repository_owner, github.event.repository.name, github.event.pull_request.number) || '' }}
   GRADLE_PUSH_TO_REMOTE_CACHE: ${{ (github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache) }}
   GRADLE_DISABLE_REMOTE_CACHE: ${{ !inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache) }}
-  # PR scope: -PpushToCache=false disables Genesis shared remote only; Gradle HTTP remote stays on (init.d).
   GRADLE_GENESIS_PUSH_TO_CACHE: ${{ (github.event_name != 'pull_request' || !inputs.enable-pr-cache) && ((github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache)) || false }}
   GRADLE_GENESIS_DISABLE_REMOTE_CACHE: ${{ (github.event_name != 'pull_request' || !inputs.enable-pr-cache) && (!inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache)) }}
 
-# A workflow run is called from the devops appdev-workflow repos
 jobs:
   build-server:
     runs-on: [ appdev-selfhosted-al2023 ]
@@ -153,7 +151,7 @@ jobs:
         working-directory: "${{ inputs.working-directory }}"
         shell: bash
         run: |
-          HASH=$(git ls-files -z server client | git hash-object --stdin)
+          HASH=$( (git ls-files -z server; git ls-files -z client 2>/dev/null || true) | sort -zu | git hash-object --stdin)
           echo "DIST_INPUT_HASH=${HASH}" >> "$GITHUB_ENV"
 
       - name: Set up JDK
@@ -319,20 +317,10 @@ jobs:
             -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }}
             ${{ inputs.server-build-gradle-arguments }}
 
-      - name: Warm compile cache when dist zip reused (PR-scoped)
-        if: env.PR_CACHE_SCOPE != '' && steps.pr-dist-cache.outputs.cache-hit == 'true'
-        working-directory: "${{ inputs.working-directory }}/server"
-        shell: bash
-        run: |
-          ./gradlew classes compileTestKotlin \
-            -Pversion=${{ env.RELEASE_VERSION }} \
-            -PgenesisArtifactoryUser="${{ secrets.JFROG_USERNAME }}" \
-            -PgenesisArtifactoryPassword="${{ secrets.JFROG_PASSWORD }}" \
-            -PpushToCache=false \
-            -PdisableRemoteCache=false \
-            ${{ env.CACHE_OPTS }} \
-            --build-cache \
-            ${{ inputs.server-build-gradle-arguments }}
+      # When dist zip is restored from GHA, Scan skips appDistZip. Do not run a warm
+      # compile here — it recompiles test sources and forces a full pbi-app:test (~12m).
+      # Build should use restored GHA + Artifactory cache (pbi-app:test FROM-CACHE) like
+      # pre-dist-cache runs when server/client are unchanged.
 
       - name: Install Bearer CLI
         if: inputs.sast

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -134,6 +134,10 @@ env:
   PR_CACHE_SCOPE: ${{ github.event_name == 'pull_request' && inputs.enable-pr-cache && format('{0}-{1}-pr-{2}', github.repository_owner, github.event.repository.name, github.event.pull_request.number) || '' }}
   GRADLE_PUSH_TO_REMOTE_CACHE: ${{ (github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache) }}
   GRADLE_DISABLE_REMOTE_CACHE: ${{ !inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache) }}
+  # PR scope: -PpushToCache=false disables Genesis shared remote only; Gradle HTTP remote stays on (init.d).
+  GRADLE_GENESIS_PUSH_TO_CACHE: ${{ env.PR_CACHE_SCOPE == '' && ((github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache)) || false }}
+  GRADLE_GENESIS_DISABLE_REMOTE_CACHE: ${{ env.PR_CACHE_SCOPE == '' && (!inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache)) }}
+  PR_SERVER_HASH: ${{ hashFiles(format('{0}/server/**/*.kt', inputs.working-directory), format('{0}/server/**/*.java', inputs.working-directory), format('{0}/server/**/*.kts', inputs.working-directory), format('{0}/server/**/build.gradle.kts', inputs.working-directory), format('{0}/server/**/build.gradle', inputs.working-directory)) }}
 
 # A workflow run is called from the devops appdev-workflow repos
 jobs:
@@ -252,22 +256,25 @@ jobs:
 
       - name: Restore Gradle cache (PR-scoped)
         if: env.PR_CACHE_SCOPE != ''
-        uses: actions/cache@v4
+        id: pr-gradle-cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             ${{ env.GRADLE_USER_HOME }}/caches
             ${{ env.GRADLE_USER_HOME }}/wrapper
-          key: ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-${{ hashFiles(format('{0}/gradle.properties', inputs.working-directory), format('{0}/**/gradle-wrapper.properties', inputs.working-directory), format('{0}/server/gradle.properties', inputs.working-directory), format('{0}/server/**/gradle-wrapper.properties', inputs.working-directory)) }}
+          key: ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-${{ env.PR_SERVER_HASH }}-${{ hashFiles(format('{0}/gradle.properties', inputs.working-directory), format('{0}/**/gradle-wrapper.properties', inputs.working-directory), format('{0}/server/gradle.properties', inputs.working-directory), format('{0}/server/**/gradle-wrapper.properties', inputs.working-directory)) }}
           restore-keys: |
+            ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-${{ env.PR_SERVER_HASH }}-
             ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-
 
       # Exact key on server sources only (no restore-keys) so scan reuses dist when code unchanged.
       - name: Restore dist zip cache (PR-scoped)
         if: env.PR_CACHE_SCOPE != ''
-        uses: actions/cache@v4
+        id: pr-dist-cache
+        uses: actions/cache/restore@v4
         with:
           path: ${{ inputs.working-directory }}/server/*/build/dist
-          key: ${{ runner.os }}-dist-${{ env.PR_CACHE_SCOPE }}-${{ hashFiles(format('{0}/server/**/*.kt', inputs.working-directory), format('{0}/server/**/*.java', inputs.working-directory), format('{0}/server/**/*.kts', inputs.working-directory), format('{0}/server/**/build.gradle.kts', inputs.working-directory), format('{0}/server/**/build.gradle', inputs.working-directory)) }}
+          key: ${{ runner.os }}-dist-${{ env.PR_CACHE_SCOPE }}-${{ env.PR_SERVER_HASH }}
 
       - name: 'Create .npmrc'
         shell: bash
@@ -303,8 +310,23 @@ jobs:
           enable-pr-cache: ${{ inputs.enable-pr-cache }}
           build-server-arguments: >-
             ${{ env.CACHE_OPTS }}
-            -PpushToCache=${{ env.PR_CACHE_SCOPE == '' && ((github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache)) || false }}
-            -PdisableRemoteCache=${{ env.PR_CACHE_SCOPE != '' && true || (!inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache)) }}
+            -PpushToCache=${{ env.GRADLE_GENESIS_PUSH_TO_CACHE }}
+            -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }}
+            ${{ inputs.server-build-gradle-arguments }}
+
+      - name: Warm compile cache when dist zip reused (PR-scoped)
+        if: env.PR_CACHE_SCOPE != '' && steps.pr-dist-cache.outputs.cache-hit == 'true'
+        working-directory: "${{ inputs.working-directory }}/server"
+        shell: bash
+        run: |
+          ./gradlew classes compileTestKotlin \
+            -Pversion=${{ env.RELEASE_VERSION }} \
+            -PgenesisArtifactoryUser="${{ secrets.JFROG_USERNAME }}" \
+            -PgenesisArtifactoryPassword="${{ secrets.JFROG_PASSWORD }}" \
+            -PpushToCache=false \
+            -PdisableRemoteCache=false \
+            ${{ env.CACHE_OPTS }} \
+            --build-cache \
             ${{ inputs.server-build-gradle-arguments }}
 
       - name: Install Bearer CLI
@@ -335,7 +357,7 @@ jobs:
       - name: Build
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build ${{ env.CACHE_OPTS }} --stacktrace -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ env.PR_CACHE_SCOPE == '' && ((github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache)) || false }} -PdisableRemoteCache=${{ env.PR_CACHE_SCOPE != '' && true || (!inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache)) }} ${{ inputs.server-build-gradle-arguments }}
+          arguments: build ${{ env.CACHE_OPTS }} --stacktrace -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ env.GRADLE_GENESIS_PUSH_TO_CACHE }} -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }} ${{ inputs.server-build-gradle-arguments }}
           build-root-directory: "${{ inputs.working-directory }}"
           cache-disabled: ${{ github.event_name != 'pull_request' || !inputs.enable-pr-cache }}
         env:
@@ -388,6 +410,13 @@ jobs:
           path: "${{ inputs.working-directory }}/server/*/build/reports/**/*"
         if: always()
 
+      - name: Remove oversized JUnit report before publish
+        if: always()
+        working-directory: "${{ inputs.working-directory }}"
+        shell: bash
+        run: |
+          find . -path '**/TEST-global.genesis.PbiReqRepTest.xml' -delete 2>/dev/null || true
+
       - name: Publish All Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
@@ -397,6 +426,22 @@ jobs:
             ./**/build/test-results/**/*.xml
           fail_on: nothing
           report_suite_logs: any
+
+      - name: Save dist zip cache (PR-scoped)
+        if: always() && env.PR_CACHE_SCOPE != ''
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ inputs.working-directory }}/server/*/build/dist
+          key: ${{ runner.os }}-dist-${{ env.PR_CACHE_SCOPE }}-${{ env.PR_SERVER_HASH }}
+
+      - name: Save Gradle cache (PR-scoped)
+        if: always() && env.PR_CACHE_SCOPE != ''
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ${{ env.GRADLE_USER_HOME }}/caches
+            ${{ env.GRADLE_USER_HOME }}/wrapper
+          key: ${{ steps.pr-gradle-cache.outputs.cache-primary-key }}
 
       - name: Docker Build Image
         if: inputs.build_docker

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -244,7 +244,7 @@ jobs:
       - name: Build
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build --no-build-cache --no-configuration-cache --stacktrace --refresh-dependencies -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=false ${{ inputs.server-build-gradle-arguments }}
+          arguments: build --no-build-cache --no-configuration-cache --stacktrace -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=false ${{ inputs.server-build-gradle-arguments }}
           build-root-directory: "${{ inputs.working-directory }}"
           cache-disabled: true
         env:

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -492,3 +492,5 @@ jobs:
       release-version: ${{ inputs.version }}
     secrets:
       JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+
+

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -139,9 +139,6 @@ env:
 jobs:
   build-server:
     runs-on: [ appdev-selfhosted-al2023 ]
-    permissions:
-      contents: read # clone repo (actions/checkout)
-      actions: write # delete/save GHA Gradle cache when enable-pr-cache is true
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -42,31 +42,6 @@ on:
         description: Push to the Artifactory cache
         default: false
         required: false
-      cache-read-only:
-        type: boolean
-        description: Whether the GitHub cache should be read-only
-        default: true
-        required: false
-      cache-write-only:
-        type: boolean
-        description: Whether the GitHub cache should be write-only
-        default: false
-        required: false
-      enable-pr-cache:
-        type: boolean
-        description: Enable caches on pull_request only (GitHub + Gradle; Artifactory when use-artifactory-cache is true)
-        default: false
-        required: false
-      disable-cache:
-        type: boolean
-        description: Deprecated — use enable-pr-cache true instead. When false, also enables PR caches (default true keeps caches off)
-        default: true
-        required: false
-      enable-configuration-cache:
-        type: boolean
-        description: Enable Gradle configuration cache when PR cache is enabled (enable-pr-cache true); validate per repo first
-        default: false
-        required: false
       working-directory:
         type: string
         default: .
@@ -139,17 +114,10 @@ on:
       SENTRY_AUTH_TOKEN:
         required: false
 
-# Caller context: PR number is empty for push/tag/dispatch — never use it alone (see reverted PR #168).
-# Group by PR id when present; otherwise event + ref so tags/releases/develop do not share one group.
-concurrency:
-  group: build-${{ github.repository }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('{0}-{1}', github.event_name, github.ref) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   NODE_AUTH_TOKEN: ${{secrets.GPR_READ_TOKEN}}
   DISTRIBUTION_DIR: ${{ inputs.distribution_dir || format('{0}-distribution', inputs.product_name) }}
-  # PR cache only when caller sets enable-pr-cache true (or disable-cache false)
-  CACHE_OPTS: ${{ (github.event_name != 'pull_request' || (!inputs.enable-pr-cache && inputs.disable-cache)) && '--no-build-cache --no-configuration-cache' || (inputs.enable-configuration-cache && '' || '--no-configuration-cache') }}
 
 # A workflow run is called from the devops appdev-workflow repos
 jobs:
@@ -169,13 +137,13 @@ jobs:
 
       - name: Configure Node  ${{ inputs.node_version }}
         if: ${{ !inputs.REGISTRY_URL  }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ inputs.node_version }}
 
       - name: Configure Node  ${{ inputs.node_version }} if using JFROG npm packages
         if: ${{ inputs.REGISTRY_URL }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ inputs.node_version }}
           registry-url: ${{ inputs.REGISTRY_URL }}
@@ -227,14 +195,6 @@ jobs:
 
           echo "GENX_BUILD_INFO=${{ github.ref_name }} / $(date -u +'%Y-%m-%d-%H%M%S') / $(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          cache-overwrite-existing: true
-          cache-read-only: ${{ github.event_name == 'pull_request' && (inputs.enable-pr-cache || !inputs.disable-cache) }}
-          cache-write-only: false
-          cache-disabled: ${{ github.event_name != 'pull_request' || (!inputs.enable-pr-cache && inputs.disable-cache) }}
-
       - name: 'Create .npmrc'
         shell: bash
         run: |
@@ -252,13 +212,13 @@ jobs:
 
       - name: Read .env file for build
         if: ${{ inputs.config-path }}
-        uses: genesislcap/appdev-workflows/read-dot-env@github_workflow_analyis
+        uses: genesislcap/appdev-workflows/read-dot-env@develop
         with:
           config-path: ${{ inputs.config-path }}
 
       - name: Scan artifact
         if: inputs.jfrogscan
-        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analyis
+        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@develop
         with:
           version: ${{ env.RELEASE_VERSION }}
           jfrog-username: ${{ secrets.JFROG_USERNAME }}
@@ -293,17 +253,26 @@ jobs:
           path: sast-report-${{ inputs.product_name }}-${{ github.run_number }}.sarif
 
       - name: Build
-        working-directory: "${{ inputs.working-directory }}"
-        run: ./gradlew build --stacktrace -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ github.event_name != 'pull_request' && inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ github.event_name != 'pull_request' || (!inputs.enable-pr-cache && inputs.disable-cache) || !inputs.use-artifactory-cache }} ${{ inputs.server-build-gradle-arguments }} ${{ env.CACHE_OPTS }}
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build --no-build-cache --no-configuration-cache --stacktrace -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }} ${{ inputs.server-build-gradle-arguments }}
+          build-root-directory: "${{ inputs.working-directory }}"
+          cache-disabled: true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
+
       - name: Test and Coverage
         if: inputs.sonar_enabled
-        working-directory: "${{ inputs.working-directory }}/server"
+        uses: gradle/gradle-build-action@v2
         env:
           SONAR_TOKEN: ${{ secrets.JENKINSGENESIS_SONAR }}
-        run: ./gradlew test jacocoTestReport sonarqube --stacktrace -Dsonar.token=${{ env.SONAR_TOKEN }} ${{ env.CACHE_OPTS }}
+        with:
+          arguments: >
+            test jacocoTestReport sonarqube --no-configuration-cache
+            -Dsonar.token=${{ env.SONAR_TOKEN }}
+          build-root-directory: "${{ inputs.working-directory }}/server"
+          cache-disabled: true
 
       - name: Check Auth Permissions task
         id: auth_permissions_task
@@ -322,7 +291,7 @@ jobs:
         shell: bash
         working-directory: "${{ inputs.working-directory }}/server"
         run: |
-          ./gradlew checkAuthPermissions --stacktrace ${{ env.CACHE_OPTS }}
+          ./gradlew checkAuthPermissions --no-configuration-cache --build-cache --stacktrace
 
       - name: Upload Genesis security permissions report
         uses: actions/upload-artifact@v4
@@ -351,20 +320,26 @@ jobs:
 
       - name: Docker Build Image
         if: inputs.build_docker
-        working-directory: "${{ inputs.working-directory }}/"
-        run: ./gradlew :genesisproduct-${{ inputs.product_name }}:${{ inputs.product_name }}-deploy:buildImage ${{ env.CACHE_OPTS }}
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: :genesisproduct-${{ inputs.product_name }}:${{ inputs.product_name }}-deploy:buildImage
+          build-root-directory: "${{ inputs.working-directory }}/"
+          cache-disabled: true
 
       - name: Docker Push Image
         if: inputs.build_docker
-        working-directory: "${{ inputs.working-directory }}/"
-        run: ./gradlew :genesisproduct-${{ inputs.product_name }}:${{ inputs.product_name }}-deploy:pushImage ${{ env.CACHE_OPTS }}
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: :genesisproduct-${{ inputs.product_name }}:${{ inputs.product_name }}-deploy:pushImage
+          build-root-directory: "${{ inputs.working-directory }}/"
+          cache-disabled: true
 
       - name: Create Giant Server Zip
         if: inputs.upload
         shell: bash
         working-directory: "${{ inputs.working-directory }}/server"
         run: |
-          ./gradlew tasks -Pversion=${{ env.RELEASE_VERSION }} ${{ env.CACHE_OPTS }} | grep install- | cut -d " " -f1 | xargs -I{} ./gradlew -Pversion=${{ env.RELEASE_VERSION }} {} ${{ inputs.server-install-gradle-arguments }} ${{ env.CACHE_OPTS }}
+          ./gradlew tasks -Pversion=${{ env.RELEASE_VERSION }} | grep install- | cut -d " " -f1 | xargs -I{} ./gradlew -Pversion=${{ env.RELEASE_VERSION }} {} ${{ inputs.server-install-gradle-arguments }}
           cd .genesis-home
           pwd
           ls -la
@@ -388,12 +363,15 @@ jobs:
 
       - name: Artifactory Publish
         if: inputs.publish-to-artifactory
-        working-directory: "${{ inputs.working-directory }}/server"
-        run: ./gradlew artifactoryPublish -x test -PdeployToClientRepo=false ${{ env.CACHE_OPTS }}
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: artifactoryPublish -x test --no-build-cache --no-configuration-cache -PdeployToClientRepo=false
+          build-root-directory: "${{ inputs.working-directory }}/server"
+          cache-disabled: true
 
       - name: Update Jira tickets with fix version
         if: inputs.update-jira
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: genesislcap/appdev-workflows
           path: ./appdev-workflows

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -317,10 +317,25 @@ jobs:
             -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }}
             ${{ inputs.server-build-gradle-arguments }}
 
-      # When dist zip is restored from GHA, Scan skips appDistZip. Do not run a warm
-      # compile here — it recompiles test sources and forces a full pbi-app:test (~12m).
-      # Build should use restored GHA + Artifactory cache (pbi-app:test FROM-CACHE) like
-      # pre-dist-cache runs when server/client are unchanged.
+      # Scan skips appDistZip when the dist zip was restored from GHA. May 29 still ran
+      # appDistZip in the same job before Build, which let pbi-app:test be FROM-CACHE (~30s).
+      # Re-run appDistZip here (usually UP-TO-DATE when the zip is already on disk) so Build
+      # does not execute a full pbi-app:test (~12m). Do not use warm compileTestKotlin — it
+      # recompiles test sources and forces tests to run again.
+      - name: Prime Gradle via appDistZip when dist zip restored (PR-scoped)
+        if: env.PR_CACHE_SCOPE != '' && steps.pr-dist-cache.outputs.cache-hit == 'true'
+        working-directory: "${{ inputs.working-directory }}/server"
+        shell: bash
+        run: |
+          ./gradlew appDistZip \
+            -Pversion=${{ env.RELEASE_VERSION }} \
+            -PgenesisArtifactoryUser="${{ secrets.JFROG_USERNAME }}" \
+            -PgenesisArtifactoryPassword="${{ secrets.JFROG_PASSWORD }}" \
+            -PpushToCache=false \
+            -PdisableRemoteCache=false \
+            ${{ env.CACHE_OPTS }} \
+            --build-cache \
+            ${{ inputs.server-build-gradle-arguments }}
 
       - name: Install Bearer CLI
         if: inputs.sast

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -244,7 +244,7 @@ jobs:
       - name: Build
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build --no-build-cache --no-configuration-cache --stacktrace -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=false ${{ inputs.server-build-gradle-arguments }}
+          arguments: build --no-build-cache --no-configuration-cache --stacktrace -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }} ${{ inputs.server-build-gradle-arguments }}
           build-root-directory: "${{ inputs.working-directory }}"
           cache-disabled: true
         env:

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -285,7 +285,7 @@ jobs:
 
       - name: Scan artifact
         if: inputs.jfrogscan
-        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analyis
+        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@workflow_jrog_cache
         with:
           version: ${{ env.RELEASE_VERSION }}
           jfrog-username: ${{ secrets.JFROG_USERNAME }}

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -45,8 +45,8 @@ on:
       enable-pr-cache:
         type: boolean
         description: >-
-          PR builds only. When true, scopes Gradle build cache per client repo and PR
-          (GitHub Actions cache, isolated GRADLE_USER_HOME, optional Artifactory remote when use-artifactory-cache is true).
+          PR builds only. When true, scopes Gradle and dist-zip cache per client repo and PR
+          (GitHub Actions cache, isolated GRADLE_USER_HOME, dist restore before Scan, optional Artifactory remote when use-artifactory-cache is true).
           No effect on push/tag.
         default: false
         required: false
@@ -147,6 +147,14 @@ jobs:
         with:
           fetch-depth: '0'
           ref: ${{ inputs.branch }}
+
+      - name: Set dist cache input hash
+        if: env.PR_CACHE_SCOPE != ''
+        working-directory: "${{ inputs.working-directory }}"
+        shell: bash
+        run: |
+          HASH=$(git ls-files -z server client | git hash-object --stdin)
+          echo "DIST_INPUT_HASH=${HASH}" >> "$GITHUB_ENV"
 
       - name: Set up JDK
         uses: actions/setup-java@v2
@@ -265,6 +273,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-
 
+      - name: Restore dist zip cache (PR-scoped)
+        if: env.PR_CACHE_SCOPE != ''
+        id: pr-dist-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ inputs.working-directory }}/server/*/build/dist
+          key: ${{ runner.os }}-dist-${{ env.PR_CACHE_SCOPE }}-${{ env.DIST_INPUT_HASH }}
+
       - name: 'Create .npmrc'
         shell: bash
         run: |
@@ -301,6 +317,21 @@ jobs:
             ${{ env.CACHE_OPTS }}
             -PpushToCache=${{ env.GRADLE_GENESIS_PUSH_TO_CACHE }}
             -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }}
+            ${{ inputs.server-build-gradle-arguments }}
+
+      - name: Warm compile cache when dist zip reused (PR-scoped)
+        if: env.PR_CACHE_SCOPE != '' && steps.pr-dist-cache.outputs.cache-hit == 'true'
+        working-directory: "${{ inputs.working-directory }}/server"
+        shell: bash
+        run: |
+          ./gradlew classes compileTestKotlin \
+            -Pversion=${{ env.RELEASE_VERSION }} \
+            -PgenesisArtifactoryUser="${{ secrets.JFROG_USERNAME }}" \
+            -PgenesisArtifactoryPassword="${{ secrets.JFROG_PASSWORD }}" \
+            -PpushToCache=false \
+            -PdisableRemoteCache=false \
+            ${{ env.CACHE_OPTS }} \
+            --build-cache \
             ${{ inputs.server-build-gradle-arguments }}
 
       - name: Install Bearer CLI
@@ -400,6 +431,13 @@ jobs:
             ./**/build/test-results/**/*.xml
           fail_on: nothing
           report_suite_logs: any
+
+      - name: Save dist zip cache (PR-scoped)
+        if: always() && env.PR_CACHE_SCOPE != ''
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ inputs.working-directory }}/server/*/build/dist
+          key: ${{ runner.os }}-dist-${{ env.PR_CACHE_SCOPE }}-${{ env.DIST_INPUT_HASH }}
 
       - name: Save Gradle cache (PR-scoped)
         if: always() && env.PR_CACHE_SCOPE != ''

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -49,6 +49,13 @@ on:
         description: Push to the Artifactory cache
         default: false
         required: false
+      enable-pr-cache:
+        type: boolean
+        description: >-
+          PR only. Enables GitHub Gradle cache read/write and Artifactory remote build cache
+          when use-artifactory-cache is true. No effect on push/tag when false (default).
+        default: false
+        required: false
       working-directory:
         type: string
         default: .
@@ -146,11 +153,16 @@ on:
       JFROG_NPM_AUTH_TOKEN:
         required: false
 
+# PR number is only set on pull_request; for push/tag use event + ref (see reverted PR #168).
+concurrency:
+  group: build-${{ github.repository }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('{0}-{1}', github.event_name, github.ref) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && !inputs.enable-pr-cache }}
+
 env:
   NODE_AUTH_TOKEN: ${{secrets.GPR_READ_TOKEN}}
   DISTRIBUTION_DIR: ${{ inputs.distribution_dir || format('{0}-distribution', inputs.product_name) }}
   APP_MODULE: ${{ inputs.app_module || format('{0}-app', inputs.product_name) }}
-  CACHE_OPTS: ${{ inputs.disable-cache && '--no-build-cache --no-configuration-cache' || '' }}
+  CACHE_OPTS: ${{ (github.event_name != 'pull_request' || !inputs.enable-pr-cache) && '--no-build-cache --no-configuration-cache' || '' }}
 
 # A workflow run is called from the devops appdev-workflow repos
 jobs:
@@ -244,9 +256,9 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
         with:
           cache-overwrite-existing: true
-          cache-read-only: ${{ inputs.cache-read-only }}
+          cache-read-only: ${{ !(github.event_name == 'pull_request' && inputs.enable-pr-cache) && inputs.cache-read-only }}
           cache-write-only: ${{ inputs.cache-write-only }}
-          cache-disabled: ${{ inputs.disable-cache }}
+          cache-disabled: ${{ !(github.event_name == 'pull_request' && inputs.enable-pr-cache) && inputs.disable-cache }}
 
       - name: Install Sast CLI
         if: inputs.sast
@@ -276,7 +288,7 @@ jobs:
 
       - name: Server Build
         if: ${{ !inputs.skip-tests }}
-        run: ./gradlew build --stacktrace -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }} ${{ inputs.server-build-gradle-arguments }} ${{ env.CACHE_OPTS }}
+        run: ./gradlew build --stacktrace -PpushToCache=${{ (github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache) }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache) }} ${{ inputs.server-build-gradle-arguments }} ${{ env.CACHE_OPTS }}
         working-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
       
       - name: Server Assemble
@@ -284,8 +296,8 @@ jobs:
         run: |
           ./gradlew assemble \
             --stacktrace \
-            -PpushToCache=${{ inputs.push-to-artifactory-cache }} \
-            -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }} \
+            -PpushToCache=${{ (github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache) }} \
+            -PdisableRemoteCache=${{ !inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache) }} \
             ${{ inputs.server-build-gradle-arguments }} \
             ${{ env.CACHE_OPTS }}
         working-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
@@ -302,7 +314,11 @@ jobs:
           working-directory: ${{ inputs.working-directory }}
           server-path: ${{ inputs.server-path }}
           app-name: ${{ inputs.product_name }}
-          build-server-arguments: ${{ inputs.server-build-gradle-arguments }}
+          build-server-arguments: >-
+            ${{ env.CACHE_OPTS }}
+            -PpushToCache=${{ (github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache) }}
+            -PdisableRemoteCache=${{ !inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache) }}
+            ${{ inputs.server-build-gradle-arguments }}
 
       - name: Copy Test Reports
         working-directory: "${{ inputs.working-directory }}"

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -294,7 +294,7 @@ jobs:
       # on disk and completes as UP-TO-DATE, avoiding a second full compilation.
       - name: Scan artifact
         if: inputs.jfrogscan
-        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analysis
+        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analyis
         with:
           version: ${{ env.RELEASE_VERSION }}
           jfrog-username: ${{ secrets.JFROG_USERNAME }}
@@ -410,7 +410,7 @@ jobs:
 
   build-web:
     if: ${{ inputs.build_web }}
-    runs-on: [ appdev-selfhosted-al2023 ]
+    runs-on: [ self-hosted, selfhosted-services ]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -378,8 +378,21 @@ jobs:
             -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }}
             ${{ inputs.server-build-gradle-arguments }}
 
-      # When dist zip is restored from GHA, Scan skips appDistZip. No warm compile step —
-      # it invalidates test UP-TO-DATE/FROM-CACHE and forces full pbi-app:test on Build.
+      # Same-job appDistZip after Scan (May 29 behaviour) when dist zip came from GHA.
+      - name: Prime Gradle via appDistZip when dist zip restored (PR-scoped)
+        if: env.PR_CACHE_SCOPE != '' && steps.pr-dist-cache.outputs.cache-hit == 'true'
+        working-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
+        shell: bash
+        run: |
+          ./gradlew appDistZip \
+            -Pversion=${{ env.RELEASE_VERSION }} \
+            -PgenesisArtifactoryUser="${{ secrets.JFROG_USERNAME }}" \
+            -PgenesisArtifactoryPassword="${{ secrets.JFROG_PASSWORD }}" \
+            -PpushToCache=false \
+            -PdisableRemoteCache=false \
+            ${{ env.CACHE_OPTS }} \
+            --build-cache \
+            ${{ inputs.server-build-gradle-arguments }}
 
       - name: Server Build
         if: ${{ !inputs.skip-tests }}

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -156,7 +156,7 @@ env:
 jobs:
   build-server:
     if: ${{ inputs.build_server }}
-    runs-on: [ appdev-selfhosted-al2023 ]
+    runs-on: [ self-hosted, selfhosted-services ]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -163,7 +163,7 @@ env:
   NODE_AUTH_TOKEN: ${{secrets.GPR_READ_TOKEN}}
   DISTRIBUTION_DIR: ${{ inputs.distribution_dir || format('{0}-distribution', inputs.product_name) }}
   APP_MODULE: ${{ inputs.app_module || format('{0}-app', inputs.product_name) }}
-  CACHE_OPTS: ${{ (github.event_name != 'pull_request' || !inputs.enable-pr-cache) && '--no-build-cache --no-configuration-cache' || '' }}
+  CACHE_OPTS: ${{ (github.event_name != 'pull_request' || !inputs.enable-pr-cache) && '--no-build-cache --no-configuration-cache' || '--build-cache' }}
   PR_CACHE_SCOPE: ${{ github.event_name == 'pull_request' && inputs.enable-pr-cache && format('{0}-{1}-pr-{2}', github.repository_owner, github.event.repository.name, github.event.pull_request.number) || '' }}
   GRADLE_PUSH_TO_REMOTE_CACHE: ${{ (github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache) }}
   GRADLE_DISABLE_REMOTE_CACHE: ${{ !inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache) }}
@@ -297,14 +297,14 @@ jobs:
           sed -E -i "s/^\s{4}version = \".+\"/    version = \"${RELEASE_VERSION}\"/g" ${{ inputs.server-path }}/build.gradle.kts
           sed -E -i "s/^version=.+/version=${RELEASE_VERSION}/g" ${{ inputs.server-path }}/gradle.properties
 
-      - name: Cache Gradle (PR-scoped)
+      - name: Restore Gradle cache (PR-scoped)
         if: env.PR_CACHE_SCOPE != ''
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: |
             ${{ env.GRADLE_USER_HOME }}/caches
             ${{ env.GRADLE_USER_HOME }}/wrapper
-          key: ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-${{ hashFiles(format('{0}/gradle.properties', inputs.working-directory), format('{0}/**/gradle-wrapper.properties', inputs.working-directory), format('{0}/{1}/gradle.properties', inputs.working-directory, inputs.server-path), format('{0}/{1}/**/gradle-wrapper.properties', inputs.working-directory, inputs.server-path)) }}
+          key: ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-${{ github.run_id }}
           restore-keys: |
             ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-
 
@@ -412,6 +412,15 @@ jobs:
             ./**/build/test-results/**/*.xml
           fail_on: nothing
           report_suite_logs: any
+
+      - name: Save Gradle cache (PR-scoped)
+        if: always() && env.PR_CACHE_SCOPE != ''
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ${{ env.GRADLE_USER_HOME }}/caches
+            ${{ env.GRADLE_USER_HOME }}/wrapper
+          key: ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-${{ github.run_id }}
 
       - name: Docker Build Image
         if: inputs.build_docker
@@ -595,14 +604,14 @@ jobs:
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
           sed -E -i "s/^\s{4}version = \".+\"/    version = \"${RELEASE_VERSION}\"/g" ${{ inputs.server-path }}/build.gradle.kts
 
-      - name: Cache Gradle (PR-scoped)
+      - name: Restore Gradle cache (PR-scoped)
         if: env.PR_CACHE_SCOPE != ''
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: |
             ${{ env.GRADLE_USER_HOME }}/caches
             ${{ env.GRADLE_USER_HOME }}/wrapper
-          key: ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-${{ hashFiles(format('{0}/gradle.properties', inputs.working-directory), format('{0}/**/gradle-wrapper.properties', inputs.working-directory), format('{0}/{1}/gradle.properties', inputs.working-directory, inputs.server-path), format('{0}/{1}/**/gradle-wrapper.properties', inputs.working-directory, inputs.server-path)) }}
+          key: ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-${{ github.run_id }}
           restore-keys: |
             ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-
 
@@ -635,6 +644,15 @@ jobs:
         run: |
           mv web-distribution-${{ env.RELEASE_VERSION }}.zip ${{ env.REPO_NAME }}-web-${{ env.RELEASE_VERSION }}.zip
           curl -u ${{ secrets.JFROG_USERNAME }}:"${{secrets.JFROG_PASSWORD}}" -X PUT "https://genesisglobal.jfrog.io/artifactory/product/${{ env.REPO_NAME }}/web/" -T *.zip
+
+      - name: Save Gradle cache (PR-scoped)
+        if: always() && env.PR_CACHE_SCOPE != ''
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ${{ env.GRADLE_USER_HOME }}/caches
+            ${{ env.GRADLE_USER_HOME }}/wrapper
+          key: ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-${{ github.run_id }}
 
       - name: Notify failure on Slack
         uses: youscan/gitactions-slack-notification@3.0.0

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -49,14 +49,6 @@ on:
         description: Push to the Artifactory cache
         default: false
         required: false
-      enable-pr-cache:
-        type: boolean
-        description: >-
-          PR only. Scopes Gradle and dist-zip cache per client repo and PR (GitHub Actions cache,
-          GRADLE_USER_HOME, dist restore for Scan, optional Artifactory remote when use-artifactory-cache is true).
-          No effect on push/tag when false (default).
-        default: false
-        required: false
       working-directory:
         type: string
         default: .
@@ -120,7 +112,7 @@ on:
       jfrogscan:
         required: false
         default: true
-        type: boolean   
+        type: boolean
       prbuild:
         required: false
         default: false
@@ -154,27 +146,17 @@ on:
       JFROG_NPM_AUTH_TOKEN:
         required: false
 
-# PR number is only set on pull_request; for push/tag use event + ref (see reverted PR #168).
-concurrency:
-  group: build-${{ github.repository }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('{0}-{1}', github.event_name, github.ref) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' && !inputs.enable-pr-cache }}
-
 env:
   NODE_AUTH_TOKEN: ${{secrets.GPR_READ_TOKEN}}
   DISTRIBUTION_DIR: ${{ inputs.distribution_dir || format('{0}-distribution', inputs.product_name) }}
   APP_MODULE: ${{ inputs.app_module || format('{0}-app', inputs.product_name) }}
-  CACHE_OPTS: ${{ (github.event_name != 'pull_request' || !inputs.enable-pr-cache) && '--no-build-cache --no-configuration-cache' || '--build-cache' }}
-  PR_CACHE_SCOPE: ${{ github.event_name == 'pull_request' && inputs.enable-pr-cache && format('{0}-{1}-pr-{2}', github.repository_owner, github.event.repository.name, github.event.pull_request.number) || '' }}
-  GRADLE_PUSH_TO_REMOTE_CACHE: ${{ (github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache) }}
-  GRADLE_DISABLE_REMOTE_CACHE: ${{ !inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache) }}
-  GRADLE_GENESIS_PUSH_TO_CACHE: ${{ (github.event_name != 'pull_request' || !inputs.enable-pr-cache) && ((github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache)) || false }}
-  GRADLE_GENESIS_DISABLE_REMOTE_CACHE: ${{ (github.event_name != 'pull_request' || !inputs.enable-pr-cache) && (!inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache)) }}
+  CACHE_OPTS: ${{ inputs.disable-cache && '--no-build-cache --no-configuration-cache' || '' }}
 
 # A workflow run is called from the devops appdev-workflow repos
 jobs:
   build-server:
     if: ${{ inputs.build_server }}
-    runs-on: [ self-hosted, selfhosted-services ]
+    runs-on: [ appdev-selfhosted-al2023 ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -183,13 +165,13 @@ jobs:
 
       - name: Configure Node
         if: ${{ !inputs.REGISTRY_URL  }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ inputs.node_version }}
 
       - name: Configure Node if using JFROG npm packages
         if: ${{ inputs.REGISTRY_URL }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ inputs.node_version }}
           registry-url: ${{ inputs.REGISTRY_URL }}
@@ -222,71 +204,32 @@ jobs:
           registry: genesisglobal-docker-remote.jfrog.io
           username: ${{ secrets.JFROG_USERNAME }}
           password: ${{ secrets.JFROG_PASSWORD }}
-          
+
       - name: Restore gradle.properties and setup
         env:
           GRADLE_PROPERTIES: ${{ secrets.GRADLE_PROPERTIES }}
-          GENESIS_ARTIFACTORY_USER: ${{ secrets.JFROG_USERNAME }}
-          GENESIS_ARTIFACTORY_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
         working-directory: "${{ inputs.working-directory }}"
         shell: bash
         run: |
-          if [ -n "${{ env.PR_CACHE_SCOPE }}" ]; then
-            GRADLE_HOME_DIR="${RUNNER_TEMP}/gradle-${{ env.PR_CACHE_SCOPE }}"
-            mkdir -p "${GRADLE_HOME_DIR}/init.d"
-            echo "GRADLE_USER_HOME=${GRADLE_HOME_DIR}" >> "$GITHUB_ENV"
-            echo "PR_CACHE_SCOPE=${{ env.PR_CACHE_SCOPE }}" >> "$GITHUB_ENV"
-            echo "GENESIS_ARTIFACTORY_USER=${GENESIS_ARTIFACTORY_USER}" >> "$GITHUB_ENV"
-            echo "GENESIS_ARTIFACTORY_PASSWORD=${GENESIS_ARTIFACTORY_PASSWORD}" >> "$GITHUB_ENV"
-            echo "GRADLE_PUSH_TO_REMOTE_CACHE=${{ env.GRADLE_PUSH_TO_REMOTE_CACHE }}" >> "$GITHUB_ENV"
-            echo "GRADLE_DISABLE_REMOTE_CACHE=${{ env.GRADLE_DISABLE_REMOTE_CACHE }}" >> "$GITHUB_ENV"
-            cat > "${GRADLE_HOME_DIR}/init.d/pr-cache-remote-scope.init.gradle" << 'INIT_SCRIPT'
-          gradle.beforeSettings { settings ->
-            def scope = System.getenv('PR_CACHE_SCOPE')
-            if (scope == null || scope.isEmpty()) {
-              return
-            }
-            def pushToCache = System.getenv('GRADLE_PUSH_TO_REMOTE_CACHE') == 'true'
-            def user = System.getenv('GENESIS_ARTIFACTORY_USER')
-            def password = System.getenv('GENESIS_ARTIFACTORY_PASSWORD')
-            settings.buildCache {
-              local { enabled = true }
-              remote(org.gradle.caching.http.HttpBuildCache) {
-                url = uri("https://genesisglobal.jfrog.io/genesisglobal/gradle-cache-repo/${scope}/")
-                credentials {
-                  username = user
-                  password = password
-                }
-                push = pushToCache
-                enabled = true
-              }
-            }
-          }
-          INIT_SCRIPT
-            echo "Using PR-isolated GRADLE_USER_HOME: ${GRADLE_HOME_DIR}"
-          else
-            mkdir -p "${HOME}/.gradle"
-            GRADLE_HOME_DIR="${HOME}/.gradle"
-            echo "GRADLE_USER_HOME=${GRADLE_HOME_DIR}" >> "$GITHUB_ENV"
-          fi
+          mkdir -p ~/.gradle/
+          echo "GRADLE_USER_HOME=${HOME}/.gradle" >> $GITHUB_ENV
+          echo "genesisArtifactoryUser=${{ secrets.JFROG_USERNAME }}" > ~/.gradle/gradle.properties
+          echo "genesisArtifactoryPassword=${{ secrets.JFROG_PASSWORD }}" >> ~/.gradle/gradle.properties
 
-          echo "genesisArtifactoryUser=${{ secrets.JFROG_USERNAME }}" > "${GRADLE_HOME_DIR}/gradle.properties"
-          echo "genesisArtifactoryPassword=${{ secrets.JFROG_PASSWORD }}" >> "${GRADLE_HOME_DIR}/gradle.properties"
+          echo "systemProp.org.gradle.internal.http.connectionTimeout=180000" >> ~/.gradle/gradle.properties
+          echo "systemProp.org.gradle.internal.http.socketTimeout=180000" >> ~/.gradle/gradle.properties
 
-          echo "systemProp.org.gradle.internal.http.connectionTimeout=180000" >> "${GRADLE_HOME_DIR}/gradle.properties"
-          echo "systemProp.org.gradle.internal.http.socketTimeout=180000" >> "${GRADLE_HOME_DIR}/gradle.properties"
+          echo "dockerUrl=genesisglobal-docker-internal.jfrog.io" >> ~/.gradle/gradle.properties
+          echo "dockerUsername=${{ secrets.JFROG_USERNAME }}" >> ~/.gradle/gradle.properties
+          echo "dockerPassword=${{ secrets.JFROG_PASSWORD }}" >> ~/.gradle/gradle.properties
+          echo "dockerEmail=platformmanageteam@genesis.global" >> ~/.gradle/gradle.properties
 
-          echo "dockerUrl=genesisglobal-docker-internal.jfrog.io" >> "${GRADLE_HOME_DIR}/gradle.properties"
-          echo "dockerUsername=${{ secrets.JFROG_USERNAME }}" >> "${GRADLE_HOME_DIR}/gradle.properties"
-          echo "dockerPassword=${{ secrets.JFROG_PASSWORD }}" >> "${GRADLE_HOME_DIR}/gradle.properties"
-          echo "dockerEmail=platformmanageteam@genesis.global" >> "${GRADLE_HOME_DIR}/gradle.properties"
-
-          echo "genesis-home=../.genesis-home" >> "${GRADLE_HOME_DIR}/gradle.properties"
-          echo "deploy-plugin-mode=local" >> "${GRADLE_HOME_DIR}/gradle.properties"
+          echo "genesis-home=../.genesis-home" >> ~/.gradle/gradle.properties
+          echo "deploy-plugin-mode=local" >> ~/.gradle/gradle.properties
           sudo chmod +x ./gradlew
           sudo chmod +x ./${{ inputs.server-path }}/gradlew
           sudo chmod -R +rx ./${{ inputs.server-path }}/
-          cat "${GRADLE_HOME_DIR}/gradle.properties" >> ./gradle.properties
+          cat ~/.gradle/gradle.properties >>  ./gradle.properties
           if [ -z "${{ inputs.repo-name }}" ]; then
             echo "REPO_NAME=$(echo '${{ github.event.repository.name }}' | cut -d'-' -f1)" >> $GITHUB_ENV
           else
@@ -297,24 +240,32 @@ jobs:
           sed -E -i "s/^\s{4}version = \".+\"/    version = \"${RELEASE_VERSION}\"/g" ${{ inputs.server-path }}/build.gradle.kts
           sed -E -i "s/^version=.+/version=${RELEASE_VERSION}/g" ${{ inputs.server-path }}/gradle.properties
 
-      - name: Restore Gradle cache (PR-scoped)
-        if: env.PR_CACHE_SCOPE != ''
-        uses: actions/cache/restore@v4
+      - name: Login to Genesis Container Registry
+        uses: docker/login-action@v3
         with:
-          path: |
-            ${{ env.GRADLE_USER_HOME }}/caches
-            ${{ env.GRADLE_USER_HOME }}/wrapper
-          key: ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-
+          registry: genesisglobal-docker-remote.jfrog.io
+          username: ${{ secrets.JFROG_USERNAME }}
+          password: ${{ secrets.JFROG_PASSWORD }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          cache-overwrite-existing: ${{ !inputs.enable-pr-cache }}
-          cache-read-only: ${{ env.PR_CACHE_SCOPE == '' && inputs.cache-read-only }}
+          cache-overwrite-existing: true
+          cache-read-only: ${{ inputs.cache-read-only }}
           cache-write-only: ${{ inputs.cache-write-only }}
-          cache-disabled: ${{ env.PR_CACHE_SCOPE != '' || (!(github.event_name == 'pull_request' && inputs.enable-pr-cache) && inputs.disable-cache) }}
+          cache-disabled: ${{ inputs.disable-cache }}
+
+      - name: Scan artifact
+        if: inputs.jfrogscan
+        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@develop
+        with:
+          version: ${{ env.RELEASE_VERSION }}
+          jfrog-username: ${{ secrets.JFROG_USERNAME }}
+          jfrog-password: ${{ secrets.JFROG_PASSWORD }}
+          working-directory: ${{ inputs.working-directory }}
+          server-path: ${{ inputs.server-path }}
+          app-name: ${{ inputs.product_name }}
+          build-server-arguments: ${{ inputs.server-build-gradle-arguments }}
 
       - name: Install Sast CLI
         if: inputs.sast
@@ -342,26 +293,9 @@ jobs:
           name: sast-report-${{ inputs.product_name }}-${{ github.run_number }}
           path: sast-report-${{ inputs.product_name }}-${{ github.run_number }}.SARIF
 
-      - name: Scan artifact
-        if: inputs.jfrogscan
-        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@workflow_jfrog_cache
-        with:
-          version: ${{ env.RELEASE_VERSION }}
-          jfrog-username: ${{ secrets.JFROG_USERNAME }}
-          jfrog-password: ${{ secrets.JFROG_PASSWORD }}
-          working-directory: ${{ inputs.working-directory }}
-          server-path: ${{ inputs.server-path }}
-          app-name: ${{ inputs.product_name }}
-          enable-pr-cache: ${{ inputs.enable-pr-cache }}
-          build-server-arguments: >-
-            ${{ env.CACHE_OPTS }}
-            -PpushToCache=${{ env.GRADLE_GENESIS_PUSH_TO_CACHE }}
-            -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }}
-            ${{ inputs.server-build-gradle-arguments }}
-
       - name: Server Build
         if: ${{ !inputs.skip-tests }}
-        run: ./gradlew build --stacktrace -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ env.GRADLE_GENESIS_PUSH_TO_CACHE }} -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }} ${{ inputs.server-build-gradle-arguments }} ${{ env.CACHE_OPTS }}
+        run: ./gradlew build --stacktrace -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }} ${{ inputs.server-build-gradle-arguments }} ${{ env.CACHE_OPTS }}
         working-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
 
       - name: Server Assemble
@@ -369,9 +303,8 @@ jobs:
         run: |
           ./gradlew assemble \
             --stacktrace \
-            -Pversion=${{ env.RELEASE_VERSION }} \
-            -PpushToCache=${{ env.GRADLE_GENESIS_PUSH_TO_CACHE }} \
-            -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }} \
+            -PpushToCache=${{ inputs.push-to-artifactory-cache }} \
+            -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }} \
             ${{ inputs.server-build-gradle-arguments }} \
             ${{ env.CACHE_OPTS }}
         working-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
@@ -396,13 +329,6 @@ jobs:
           path: "${{ inputs.working-directory }}/test-results"
         if: always()
 
-      - name: Remove oversized JUnit report before publish
-        if: always()
-        working-directory: "${{ inputs.working-directory }}"
-        shell: bash
-        run: |
-          find . -path '**/TEST-global.genesis.PbiReqRepTest.xml' -delete 2>/dev/null || true
-
       - name: Publish All Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
@@ -412,15 +338,6 @@ jobs:
             ./**/build/test-results/**/*.xml
           fail_on: nothing
           report_suite_logs: any
-
-      - name: Save Gradle cache (PR-scoped)
-        if: success() && env.PR_CACHE_SCOPE != ''
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            ${{ env.GRADLE_USER_HOME }}/caches
-            ${{ env.GRADLE_USER_HOME }}/wrapper
-          key: ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-${{ github.run_id }}
 
       - name: Docker Build Image
         if: inputs.build_docker
@@ -498,7 +415,7 @@ jobs:
 
   build-web:
     if: ${{ inputs.build_web }}
-    runs-on: [ self-hosted, selfhosted-services ]
+    runs-on: [ appdev-selfhosted-al2023 ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -507,13 +424,13 @@ jobs:
 
       - name: Configure Node
         if: ${{ !inputs.REGISTRY_URL  }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ inputs.node_version }}
 
       - name: Configure Node if using JFROG npm packages
         if: ${{ inputs.REGISTRY_URL }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ inputs.node_version }}
           registry-url: ${{ inputs.REGISTRY_URL }}
@@ -541,60 +458,20 @@ jobs:
           distribution: 'adopt'
 
       - name: Restore gradle.properties and setup
-        env:
-          GENESIS_ARTIFACTORY_USER: ${{ secrets.JFROG_USERNAME }}
-          GENESIS_ARTIFACTORY_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
         working-directory: "${{ inputs.working-directory }}"
         shell: bash
         run: |
-          if [ -n "${{ env.PR_CACHE_SCOPE }}" ]; then
-            GRADLE_HOME_DIR="${RUNNER_TEMP}/gradle-${{ env.PR_CACHE_SCOPE }}"
-            mkdir -p "${GRADLE_HOME_DIR}/init.d"
-            echo "GRADLE_USER_HOME=${GRADLE_HOME_DIR}" >> "$GITHUB_ENV"
-            echo "PR_CACHE_SCOPE=${{ env.PR_CACHE_SCOPE }}" >> "$GITHUB_ENV"
-            echo "GENESIS_ARTIFACTORY_USER=${GENESIS_ARTIFACTORY_USER}" >> "$GITHUB_ENV"
-            echo "GENESIS_ARTIFACTORY_PASSWORD=${GENESIS_ARTIFACTORY_PASSWORD}" >> "$GITHUB_ENV"
-            echo "GRADLE_PUSH_TO_REMOTE_CACHE=${{ env.GRADLE_PUSH_TO_REMOTE_CACHE }}" >> "$GITHUB_ENV"
-            echo "GRADLE_DISABLE_REMOTE_CACHE=${{ env.GRADLE_DISABLE_REMOTE_CACHE }}" >> "$GITHUB_ENV"
-            cat > "${GRADLE_HOME_DIR}/init.d/pr-cache-remote-scope.init.gradle" << 'INIT_SCRIPT'
-          gradle.beforeSettings { settings ->
-            def scope = System.getenv('PR_CACHE_SCOPE')
-            if (scope == null || scope.isEmpty()) {
-              return
-            }
-            def pushToCache = System.getenv('GRADLE_PUSH_TO_REMOTE_CACHE') == 'true'
-            def user = System.getenv('GENESIS_ARTIFACTORY_USER')
-            def password = System.getenv('GENESIS_ARTIFACTORY_PASSWORD')
-            settings.buildCache {
-              local { enabled = true }
-              remote(org.gradle.caching.http.HttpBuildCache) {
-                url = uri("https://genesisglobal.jfrog.io/genesisglobal/gradle-cache-repo/${scope}/")
-                credentials {
-                  username = user
-                  password = password
-                }
-                push = pushToCache
-                enabled = true
-              }
-            }
-          }
-          INIT_SCRIPT
-            echo "Using PR-isolated GRADLE_USER_HOME: ${GRADLE_HOME_DIR}"
-          else
-            mkdir -p "${HOME}/.gradle"
-            GRADLE_HOME_DIR="${HOME}/.gradle"
-            echo "GRADLE_USER_HOME=${GRADLE_HOME_DIR}" >> "$GITHUB_ENV"
-          fi
+          mkdir -p ~/.gradle/
+          echo "GRADLE_USER_HOME=${HOME}/.gradle" >> $GITHUB_ENV
+          echo "genesisArtifactoryUser=${{ secrets.JFROG_USERNAME }}" > ~/.gradle/gradle.properties
+          echo "genesisArtifactoryPassword=${{ secrets.JFROG_PASSWORD }}" >> ~/.gradle/gradle.properties
 
-          echo "genesisArtifactoryUser=${{ secrets.JFROG_USERNAME }}" > "${GRADLE_HOME_DIR}/gradle.properties"
-          echo "genesisArtifactoryPassword=${{ secrets.JFROG_PASSWORD }}" >> "${GRADLE_HOME_DIR}/gradle.properties"
-
-          echo "genesis-home=../.genesis-home" >> "${GRADLE_HOME_DIR}/gradle.properties"
-          echo "deploy-plugin-mode=local" >> "${GRADLE_HOME_DIR}/gradle.properties"
+          echo "genesis-home=../.genesis-home" >> ~/.gradle/gradle.properties
+          echo "deploy-plugin-mode=local" >> ~/.gradle/gradle.properties
           sudo chmod +x ./gradlew
           sudo chmod +x ./${{ inputs.server-path }}/gradlew
 
-          cat "${GRADLE_HOME_DIR}/gradle.properties" >> ./gradle.properties
+          cat ~/.gradle/gradle.properties >>  ./gradle.properties
           if [ -z "${{ inputs.repo-name }}" ]; then
             echo "REPO_NAME=$(echo '${{ github.event.repository.name }}' | cut -d'-' -f1)" >> $GITHUB_ENV
           else
@@ -604,16 +481,6 @@ jobs:
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
           sed -E -i "s/^\s{4}version = \".+\"/    version = \"${RELEASE_VERSION}\"/g" ${{ inputs.server-path }}/build.gradle.kts
 
-      - name: Restore Gradle cache (PR-scoped)
-        if: env.PR_CACHE_SCOPE != ''
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            ${{ env.GRADLE_USER_HOME }}/caches
-            ${{ env.GRADLE_USER_HOME }}/wrapper
-          key: ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-
 
       - name: Check file existence
         id: web_exists
@@ -634,7 +501,7 @@ jobs:
         if: steps.web_exists.outputs.client_folder_exists == 'true'
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: :${{ steps.web_exists.outputs.modified-arguments-location }}:assembleDist -x preCompileScripts -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ env.GRADLE_GENESIS_PUSH_TO_CACHE }} -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }} ${{ env.CACHE_OPTS }}
+          arguments: :${{ steps.web_exists.outputs.modified-arguments-location }}:assembleDist -x preCompileScripts --no-build-cache -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }}
           build-root-directory: "${{ inputs.working-directory }}/"
           cache-disabled: true
 
@@ -644,15 +511,6 @@ jobs:
         run: |
           mv web-distribution-${{ env.RELEASE_VERSION }}.zip ${{ env.REPO_NAME }}-web-${{ env.RELEASE_VERSION }}.zip
           curl -u ${{ secrets.JFROG_USERNAME }}:"${{secrets.JFROG_PASSWORD}}" -X PUT "https://genesisglobal.jfrog.io/artifactory/product/${{ env.REPO_NAME }}/web/" -T *.zip
-
-      - name: Save Gradle cache (PR-scoped)
-        if: success() && env.PR_CACHE_SCOPE != ''
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            ${{ env.GRADLE_USER_HOME }}/caches
-            ${{ env.GRADLE_USER_HOME }}/wrapper
-          key: ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-${{ github.run_id }}
 
       - name: Notify failure on Slack
         uses: youscan/gitactions-slack-notification@3.0.0

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -344,7 +344,7 @@ jobs:
 
       - name: Scan artifact
         if: inputs.jfrogscan
-        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@workflow_jrog_cache
+        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@workflow_jfrog_cache
         with:
           version: ${{ env.RELEASE_VERSION }}
           jfrog-username: ${{ secrets.JFROG_USERNAME }}

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -414,7 +414,7 @@ jobs:
           report_suite_logs: any
 
       - name: Save Gradle cache (PR-scoped)
-        if: always() && env.PR_CACHE_SCOPE != ''
+        if: success() && env.PR_CACHE_SCOPE != ''
         uses: actions/cache/save@v4
         with:
           path: |
@@ -646,7 +646,7 @@ jobs:
           curl -u ${{ secrets.JFROG_USERNAME }}:"${{secrets.JFROG_PASSWORD}}" -X PUT "https://genesisglobal.jfrog.io/artifactory/product/${{ env.REPO_NAME }}/web/" -T *.zip
 
       - name: Save Gradle cache (PR-scoped)
-        if: always() && env.PR_CACHE_SCOPE != ''
+        if: success() && env.PR_CACHE_SCOPE != ''
         uses: actions/cache/save@v4
         with:
           path: |

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -52,8 +52,9 @@ on:
       enable-pr-cache:
         type: boolean
         description: >-
-          PR only. Enables GitHub Gradle cache read/write and Artifactory remote build cache
-          when use-artifactory-cache is true. No effect on push/tag when false (default).
+          PR only. Enables Gradle build cache scoped per client repo and PR (GitHub Actions cache,
+          GRADLE_USER_HOME, Artifactory remote) when use-artifactory-cache is true.
+          No effect on push/tag when false (default).
         default: false
         required: false
       working-directory:
@@ -163,6 +164,11 @@ env:
   DISTRIBUTION_DIR: ${{ inputs.distribution_dir || format('{0}-distribution', inputs.product_name) }}
   APP_MODULE: ${{ inputs.app_module || format('{0}-app', inputs.product_name) }}
   CACHE_OPTS: ${{ (github.event_name != 'pull_request' || !inputs.enable-pr-cache) && '--no-build-cache --no-configuration-cache' || '' }}
+  PR_CACHE_SCOPE: ${{ github.event_name == 'pull_request' && inputs.enable-pr-cache && format('{0}-{1}-pr-{2}', github.repository_owner, github.event.repository.name, github.event.pull_request.number) || '' }}
+  GRADLE_PUSH_TO_REMOTE_CACHE: ${{ (github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache) }}
+  GRADLE_DISABLE_REMOTE_CACHE: ${{ !inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache) }}
+  GRADLE_GENESIS_PUSH_TO_CACHE: ${{ (github.event_name != 'pull_request' || !inputs.enable-pr-cache) && ((github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache)) || false }}
+  GRADLE_GENESIS_DISABLE_REMOTE_CACHE: ${{ (github.event_name != 'pull_request' || !inputs.enable-pr-cache) && (!inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache)) }}
 
 # A workflow run is called from the devops appdev-workflow repos
 jobs:
@@ -220,28 +226,67 @@ jobs:
       - name: Restore gradle.properties and setup
         env:
           GRADLE_PROPERTIES: ${{ secrets.GRADLE_PROPERTIES }}
+          GENESIS_ARTIFACTORY_USER: ${{ secrets.JFROG_USERNAME }}
+          GENESIS_ARTIFACTORY_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
         working-directory: "${{ inputs.working-directory }}"
         shell: bash
         run: |
-          mkdir -p ~/.gradle/
-          echo "GRADLE_USER_HOME=${HOME}/.gradle" >> $GITHUB_ENV
-          echo "genesisArtifactoryUser=${{ secrets.JFROG_USERNAME }}" > ~/.gradle/gradle.properties
-          echo "genesisArtifactoryPassword=${{ secrets.JFROG_PASSWORD }}" >> ~/.gradle/gradle.properties
+          if [ -n "${{ env.PR_CACHE_SCOPE }}" ]; then
+            GRADLE_HOME_DIR="${RUNNER_TEMP}/gradle-${{ env.PR_CACHE_SCOPE }}"
+            mkdir -p "${GRADLE_HOME_DIR}/init.d"
+            echo "GRADLE_USER_HOME=${GRADLE_HOME_DIR}" >> "$GITHUB_ENV"
+            echo "PR_CACHE_SCOPE=${{ env.PR_CACHE_SCOPE }}" >> "$GITHUB_ENV"
+            echo "GENESIS_ARTIFACTORY_USER=${GENESIS_ARTIFACTORY_USER}" >> "$GITHUB_ENV"
+            echo "GENESIS_ARTIFACTORY_PASSWORD=${GENESIS_ARTIFACTORY_PASSWORD}" >> "$GITHUB_ENV"
+            echo "GRADLE_PUSH_TO_REMOTE_CACHE=${{ env.GRADLE_PUSH_TO_REMOTE_CACHE }}" >> "$GITHUB_ENV"
+            echo "GRADLE_DISABLE_REMOTE_CACHE=${{ env.GRADLE_DISABLE_REMOTE_CACHE }}" >> "$GITHUB_ENV"
+            cat > "${GRADLE_HOME_DIR}/init.d/pr-cache-remote-scope.init.gradle" << 'INIT_SCRIPT'
+          gradle.beforeSettings { settings ->
+            def scope = System.getenv('PR_CACHE_SCOPE')
+            if (scope == null || scope.isEmpty()) {
+              return
+            }
+            def pushToCache = System.getenv('GRADLE_PUSH_TO_REMOTE_CACHE') == 'true'
+            def user = System.getenv('GENESIS_ARTIFACTORY_USER')
+            def password = System.getenv('GENESIS_ARTIFACTORY_PASSWORD')
+            settings.buildCache {
+              local { enabled = true }
+              remote(org.gradle.caching.http.HttpBuildCache) {
+                url = uri("https://genesisglobal.jfrog.io/genesisglobal/gradle-cache-repo/${scope}/")
+                credentials {
+                  username = user
+                  password = password
+                }
+                push = pushToCache
+                enabled = true
+              }
+            }
+          }
+          INIT_SCRIPT
+            echo "Using PR-isolated GRADLE_USER_HOME: ${GRADLE_HOME_DIR}"
+          else
+            mkdir -p "${HOME}/.gradle"
+            GRADLE_HOME_DIR="${HOME}/.gradle"
+            echo "GRADLE_USER_HOME=${GRADLE_HOME_DIR}" >> "$GITHUB_ENV"
+          fi
 
-          echo "systemProp.org.gradle.internal.http.connectionTimeout=180000" >> ~/.gradle/gradle.properties
-          echo "systemProp.org.gradle.internal.http.socketTimeout=180000" >> ~/.gradle/gradle.properties
+          echo "genesisArtifactoryUser=${{ secrets.JFROG_USERNAME }}" > "${GRADLE_HOME_DIR}/gradle.properties"
+          echo "genesisArtifactoryPassword=${{ secrets.JFROG_PASSWORD }}" >> "${GRADLE_HOME_DIR}/gradle.properties"
 
-          echo "dockerUrl=genesisglobal-docker-internal.jfrog.io" >> ~/.gradle/gradle.properties
-          echo "dockerUsername=${{ secrets.JFROG_USERNAME }}" >> ~/.gradle/gradle.properties
-          echo "dockerPassword=${{ secrets.JFROG_PASSWORD }}" >> ~/.gradle/gradle.properties
-          echo "dockerEmail=platformmanageteam@genesis.global" >> ~/.gradle/gradle.properties
+          echo "systemProp.org.gradle.internal.http.connectionTimeout=180000" >> "${GRADLE_HOME_DIR}/gradle.properties"
+          echo "systemProp.org.gradle.internal.http.socketTimeout=180000" >> "${GRADLE_HOME_DIR}/gradle.properties"
 
-          echo "genesis-home=../.genesis-home" >> ~/.gradle/gradle.properties
-          echo "deploy-plugin-mode=local" >> ~/.gradle/gradle.properties
+          echo "dockerUrl=genesisglobal-docker-internal.jfrog.io" >> "${GRADLE_HOME_DIR}/gradle.properties"
+          echo "dockerUsername=${{ secrets.JFROG_USERNAME }}" >> "${GRADLE_HOME_DIR}/gradle.properties"
+          echo "dockerPassword=${{ secrets.JFROG_PASSWORD }}" >> "${GRADLE_HOME_DIR}/gradle.properties"
+          echo "dockerEmail=platformmanageteam@genesis.global" >> "${GRADLE_HOME_DIR}/gradle.properties"
+
+          echo "genesis-home=../.genesis-home" >> "${GRADLE_HOME_DIR}/gradle.properties"
+          echo "deploy-plugin-mode=local" >> "${GRADLE_HOME_DIR}/gradle.properties"
           sudo chmod +x ./gradlew
           sudo chmod +x ./${{ inputs.server-path }}/gradlew
           sudo chmod -R +rx ./${{ inputs.server-path }}/
-          cat ~/.gradle/gradle.properties >>  ./gradle.properties
+          cat "${GRADLE_HOME_DIR}/gradle.properties" >> ./gradle.properties
           if [ -z "${{ inputs.repo-name }}" ]; then
             echo "REPO_NAME=$(echo '${{ github.event.repository.name }}' | cut -d'-' -f1)" >> $GITHUB_ENV
           else
@@ -252,13 +297,25 @@ jobs:
           sed -E -i "s/^\s{4}version = \".+\"/    version = \"${RELEASE_VERSION}\"/g" ${{ inputs.server-path }}/build.gradle.kts
           sed -E -i "s/^version=.+/version=${RELEASE_VERSION}/g" ${{ inputs.server-path }}/gradle.properties
 
+      - name: Restore Gradle cache (PR-scoped)
+        if: env.PR_CACHE_SCOPE != ''
+        id: pr-gradle-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ${{ env.GRADLE_USER_HOME }}/caches
+            ${{ env.GRADLE_USER_HOME }}/wrapper
+          key: ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-${{ hashFiles(format('{0}/gradle.properties', inputs.working-directory), format('{0}/**/gradle-wrapper.properties', inputs.working-directory), format('{0}/{1}/gradle.properties', inputs.working-directory, inputs.server-path), format('{0}/{1}/**/gradle-wrapper.properties', inputs.working-directory, inputs.server-path)) }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          cache-overwrite-existing: true
-          cache-read-only: ${{ !(github.event_name == 'pull_request' && inputs.enable-pr-cache) && inputs.cache-read-only }}
+          cache-overwrite-existing: ${{ !inputs.enable-pr-cache }}
+          cache-read-only: ${{ env.PR_CACHE_SCOPE == '' && inputs.cache-read-only }}
           cache-write-only: ${{ inputs.cache-write-only }}
-          cache-disabled: ${{ !(github.event_name == 'pull_request' && inputs.enable-pr-cache) && inputs.disable-cache }}
+          cache-disabled: ${{ env.PR_CACHE_SCOPE != '' || (!(github.event_name == 'pull_request' && inputs.enable-pr-cache) && inputs.disable-cache) }}
 
       - name: Install Sast CLI
         if: inputs.sast
@@ -288,7 +345,7 @@ jobs:
 
       - name: Server Build
         if: ${{ !inputs.skip-tests }}
-        run: ./gradlew build --stacktrace -PpushToCache=${{ (github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache) }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache) }} ${{ inputs.server-build-gradle-arguments }} ${{ env.CACHE_OPTS }}
+        run: ./gradlew build --stacktrace -PpushToCache=${{ env.GRADLE_GENESIS_PUSH_TO_CACHE }} -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }} ${{ inputs.server-build-gradle-arguments }} ${{ env.CACHE_OPTS }}
         working-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
       
       - name: Server Assemble
@@ -296,8 +353,8 @@ jobs:
         run: |
           ./gradlew assemble \
             --stacktrace \
-            -PpushToCache=${{ (github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache) }} \
-            -PdisableRemoteCache=${{ !inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache) }} \
+            -PpushToCache=${{ env.GRADLE_GENESIS_PUSH_TO_CACHE }} \
+            -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }} \
             ${{ inputs.server-build-gradle-arguments }} \
             ${{ env.CACHE_OPTS }}
         working-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
@@ -314,11 +371,21 @@ jobs:
           working-directory: ${{ inputs.working-directory }}
           server-path: ${{ inputs.server-path }}
           app-name: ${{ inputs.product_name }}
+          enable-pr-cache: ${{ inputs.enable-pr-cache }}
           build-server-arguments: >-
             ${{ env.CACHE_OPTS }}
-            -PpushToCache=${{ (github.event_name != 'pull_request' && inputs.push-to-artifactory-cache) || (github.event_name == 'pull_request' && inputs.enable-pr-cache && inputs.use-artifactory-cache) }}
-            -PdisableRemoteCache=${{ !inputs.use-artifactory-cache || (github.event_name == 'pull_request' && !inputs.enable-pr-cache) }}
+            -PpushToCache=${{ env.GRADLE_GENESIS_PUSH_TO_CACHE }}
+            -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }}
             ${{ inputs.server-build-gradle-arguments }}
+
+      - name: Save Gradle cache (PR-scoped)
+        if: always() && env.PR_CACHE_SCOPE != ''
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ${{ env.GRADLE_USER_HOME }}/caches
+            ${{ env.GRADLE_USER_HOME }}/wrapper
+          key: ${{ steps.pr-gradle-cache.outputs.cache-primary-key }}
 
       - name: Copy Test Reports
         working-directory: "${{ inputs.working-directory }}"
@@ -339,6 +406,13 @@ jobs:
           name: test-reports
           path: "${{ inputs.working-directory }}/test-results"
         if: always()
+
+      - name: Remove oversized JUnit report before publish
+        if: always()
+        working-directory: "${{ inputs.working-directory }}"
+        shell: bash
+        run: |
+          find . -path '**/TEST-global.genesis.PbiReqRepTest.xml' -delete 2>/dev/null || true
 
       - name: Publish All Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
@@ -469,20 +543,59 @@ jobs:
           distribution: 'adopt'
 
       - name: Restore gradle.properties and setup
+        env:
+          GENESIS_ARTIFACTORY_USER: ${{ secrets.JFROG_USERNAME }}
+          GENESIS_ARTIFACTORY_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
         working-directory: "${{ inputs.working-directory }}"
         shell: bash
         run: |
-          mkdir -p ~/.gradle/
-          echo "GRADLE_USER_HOME=${HOME}/.gradle" >> $GITHUB_ENV
-          echo "genesisArtifactoryUser=${{ secrets.JFROG_USERNAME }}" > ~/.gradle/gradle.properties
-          echo "genesisArtifactoryPassword=${{ secrets.JFROG_PASSWORD }}" >> ~/.gradle/gradle.properties
+          if [ -n "${{ env.PR_CACHE_SCOPE }}" ]; then
+            GRADLE_HOME_DIR="${RUNNER_TEMP}/gradle-${{ env.PR_CACHE_SCOPE }}"
+            mkdir -p "${GRADLE_HOME_DIR}/init.d"
+            echo "GRADLE_USER_HOME=${GRADLE_HOME_DIR}" >> "$GITHUB_ENV"
+            echo "PR_CACHE_SCOPE=${{ env.PR_CACHE_SCOPE }}" >> "$GITHUB_ENV"
+            echo "GENESIS_ARTIFACTORY_USER=${GENESIS_ARTIFACTORY_USER}" >> "$GITHUB_ENV"
+            echo "GENESIS_ARTIFACTORY_PASSWORD=${GENESIS_ARTIFACTORY_PASSWORD}" >> "$GITHUB_ENV"
+            echo "GRADLE_PUSH_TO_REMOTE_CACHE=${{ env.GRADLE_PUSH_TO_REMOTE_CACHE }}" >> "$GITHUB_ENV"
+            echo "GRADLE_DISABLE_REMOTE_CACHE=${{ env.GRADLE_DISABLE_REMOTE_CACHE }}" >> "$GITHUB_ENV"
+            cat > "${GRADLE_HOME_DIR}/init.d/pr-cache-remote-scope.init.gradle" << 'INIT_SCRIPT'
+          gradle.beforeSettings { settings ->
+            def scope = System.getenv('PR_CACHE_SCOPE')
+            if (scope == null || scope.isEmpty()) {
+              return
+            }
+            def pushToCache = System.getenv('GRADLE_PUSH_TO_REMOTE_CACHE') == 'true'
+            def user = System.getenv('GENESIS_ARTIFACTORY_USER')
+            def password = System.getenv('GENESIS_ARTIFACTORY_PASSWORD')
+            settings.buildCache {
+              local { enabled = true }
+              remote(org.gradle.caching.http.HttpBuildCache) {
+                url = uri("https://genesisglobal.jfrog.io/genesisglobal/gradle-cache-repo/${scope}/")
+                credentials {
+                  username = user
+                  password = password
+                }
+                push = pushToCache
+                enabled = true
+              }
+            }
+          }
+          INIT_SCRIPT
+          else
+            mkdir -p "${HOME}/.gradle"
+            GRADLE_HOME_DIR="${HOME}/.gradle"
+            echo "GRADLE_USER_HOME=${GRADLE_HOME_DIR}" >> "$GITHUB_ENV"
+          fi
 
-          echo "genesis-home=../.genesis-home" >> ~/.gradle/gradle.properties
-          echo "deploy-plugin-mode=local" >> ~/.gradle/gradle.properties
+          echo "genesisArtifactoryUser=${{ secrets.JFROG_USERNAME }}" > "${GRADLE_HOME_DIR}/gradle.properties"
+          echo "genesisArtifactoryPassword=${{ secrets.JFROG_PASSWORD }}" >> "${GRADLE_HOME_DIR}/gradle.properties"
+
+          echo "genesis-home=../.genesis-home" >> "${GRADLE_HOME_DIR}/gradle.properties"
+          echo "deploy-plugin-mode=local" >> "${GRADLE_HOME_DIR}/gradle.properties"
           sudo chmod +x ./gradlew
           sudo chmod +x ./${{ inputs.server-path }}/gradlew
 
-          cat ~/.gradle/gradle.properties >>  ./gradle.properties
+          cat "${GRADLE_HOME_DIR}/gradle.properties" >> ./gradle.properties
           if [ -z "${{ inputs.repo-name }}" ]; then
             echo "REPO_NAME=$(echo '${{ github.event.repository.name }}' | cut -d'-' -f1)" >> $GITHUB_ENV
           else
@@ -492,6 +605,16 @@ jobs:
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
           sed -E -i "s/^\s{4}version = \".+\"/    version = \"${RELEASE_VERSION}\"/g" ${{ inputs.server-path }}/build.gradle.kts
 
+      - name: Restore Gradle cache (PR-scoped)
+        if: env.PR_CACHE_SCOPE != ''
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ env.GRADLE_USER_HOME }}/caches
+            ${{ env.GRADLE_USER_HOME }}/wrapper
+          key: ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-${{ hashFiles(format('{0}/gradle.properties', inputs.working-directory), format('{0}/**/gradle-wrapper.properties', inputs.working-directory), format('{0}/{1}/gradle.properties', inputs.working-directory, inputs.server-path), format('{0}/{1}/**/gradle-wrapper.properties', inputs.working-directory, inputs.server-path)) }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-
 
       - name: Check file existence
         id: web_exists

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -52,8 +52,8 @@ on:
       enable-pr-cache:
         type: boolean
         description: >-
-          PR only. Enables Gradle build cache scoped per client repo and PR (GitHub Actions cache,
-          GRADLE_USER_HOME, Artifactory remote) when use-artifactory-cache is true.
+          PR only. Scopes Gradle and dist-zip cache per client repo and PR (GitHub Actions cache,
+          GRADLE_USER_HOME, dist restore for Scan, optional Artifactory remote when use-artifactory-cache is true).
           No effect on push/tag when false (default).
         default: false
         required: false
@@ -180,6 +180,14 @@ jobs:
         with:
           fetch-depth: '0'
           ref: ${{ inputs.branch }}
+
+      - name: Set dist cache input hash
+        if: env.PR_CACHE_SCOPE != ''
+        working-directory: "${{ inputs.working-directory }}"
+        shell: bash
+        run: |
+          HASH=$( (git ls-files -z "${{ inputs.server-path }}"; git ls-files -z server client 2>/dev/null || true) | sort -zu | git hash-object --stdin)
+          echo "DIST_INPUT_HASH=${HASH}" >> "$GITHUB_ENV"
 
       - name: Configure Node
         if: ${{ !inputs.REGISTRY_URL  }}
@@ -309,6 +317,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-
 
+      - name: Restore dist zip cache (PR-scoped)
+        if: env.PR_CACHE_SCOPE != ''
+        id: pr-dist-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ${{ inputs.working-directory }}/server/*/build/dist
+            ${{ inputs.working-directory }}/${{ inputs.server-path }}/*/build/dist
+          key: ${{ runner.os }}-dist-${{ env.PR_CACHE_SCOPE }}-${{ env.DIST_INPUT_HASH }}
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
@@ -343,24 +361,6 @@ jobs:
           name: sast-report-${{ inputs.product_name }}-${{ github.run_number }}
           path: sast-report-${{ inputs.product_name }}-${{ github.run_number }}.SARIF
 
-      - name: Server Build
-        if: ${{ !inputs.skip-tests }}
-        run: ./gradlew build --stacktrace -PpushToCache=${{ env.GRADLE_GENESIS_PUSH_TO_CACHE }} -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }} ${{ inputs.server-build-gradle-arguments }} ${{ env.CACHE_OPTS }}
-        working-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
-      
-      - name: Server Assemble
-        if: inputs.skip-tests
-        run: |
-          ./gradlew assemble \
-            --stacktrace \
-            -PpushToCache=${{ env.GRADLE_GENESIS_PUSH_TO_CACHE }} \
-            -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }} \
-            ${{ inputs.server-build-gradle-arguments }} \
-            ${{ env.CACHE_OPTS }}
-        working-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
-
-      # Runs after the build so Gradle's appDistZip task finds its outputs already
-      # on disk and completes as UP-TO-DATE, avoiding a second full compilation.
       - name: Scan artifact
         if: inputs.jfrogscan
         uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analyis
@@ -378,14 +378,37 @@ jobs:
             -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }}
             ${{ inputs.server-build-gradle-arguments }}
 
-      - name: Save Gradle cache (PR-scoped)
-        if: always() && env.PR_CACHE_SCOPE != ''
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            ${{ env.GRADLE_USER_HOME }}/caches
-            ${{ env.GRADLE_USER_HOME }}/wrapper
-          key: ${{ steps.pr-gradle-cache.outputs.cache-primary-key }}
+      - name: Warm compile cache when dist zip reused (PR-scoped)
+        if: env.PR_CACHE_SCOPE != '' && steps.pr-dist-cache.outputs.cache-hit == 'true'
+        working-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
+        shell: bash
+        run: |
+          ./gradlew classes compileTestKotlin \
+            -Pversion=${{ env.RELEASE_VERSION }} \
+            -PgenesisArtifactoryUser="${{ secrets.JFROG_USERNAME }}" \
+            -PgenesisArtifactoryPassword="${{ secrets.JFROG_PASSWORD }}" \
+            -PpushToCache=false \
+            -PdisableRemoteCache=false \
+            ${{ env.CACHE_OPTS }} \
+            --build-cache \
+            ${{ inputs.server-build-gradle-arguments }}
+
+      - name: Server Build
+        if: ${{ !inputs.skip-tests }}
+        run: ./gradlew build --stacktrace -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ env.GRADLE_GENESIS_PUSH_TO_CACHE }} -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }} ${{ inputs.server-build-gradle-arguments }} ${{ env.CACHE_OPTS }}
+        working-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
+
+      - name: Server Assemble
+        if: inputs.skip-tests
+        run: |
+          ./gradlew assemble \
+            --stacktrace \
+            -Pversion=${{ env.RELEASE_VERSION }} \
+            -PpushToCache=${{ env.GRADLE_GENESIS_PUSH_TO_CACHE }} \
+            -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }} \
+            ${{ inputs.server-build-gradle-arguments }} \
+            ${{ env.CACHE_OPTS }}
+        working-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
 
       - name: Copy Test Reports
         working-directory: "${{ inputs.working-directory }}"
@@ -423,6 +446,24 @@ jobs:
             ./**/build/test-results/**/*.xml
           fail_on: nothing
           report_suite_logs: any
+
+      - name: Save dist zip cache (PR-scoped)
+        if: always() && env.PR_CACHE_SCOPE != ''
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ${{ inputs.working-directory }}/server/*/build/dist
+            ${{ inputs.working-directory }}/${{ inputs.server-path }}/*/build/dist
+          key: ${{ runner.os }}-dist-${{ env.PR_CACHE_SCOPE }}-${{ env.DIST_INPUT_HASH }}
+
+      - name: Save Gradle cache (PR-scoped)
+        if: always() && env.PR_CACHE_SCOPE != ''
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ${{ env.GRADLE_USER_HOME }}/caches
+            ${{ env.GRADLE_USER_HOME }}/wrapper
+          key: ${{ steps.pr-gradle-cache.outputs.cache-primary-key }}
 
       - name: Docker Build Image
         if: inputs.build_docker
@@ -507,6 +548,14 @@ jobs:
           fetch-depth: '0'
           ref: ${{ inputs.branch }}
 
+      - name: Set dist cache input hash
+        if: env.PR_CACHE_SCOPE != ''
+        working-directory: "${{ inputs.working-directory }}"
+        shell: bash
+        run: |
+          HASH=$( (git ls-files -z "${{ inputs.server-path }}"; git ls-files -z server client 2>/dev/null || true) | sort -zu | git hash-object --stdin)
+          echo "DIST_INPUT_HASH=${HASH}" >> "$GITHUB_ENV"
+
       - name: Configure Node
         if: ${{ !inputs.REGISTRY_URL  }}
         uses: actions/setup-node@v4
@@ -581,6 +630,7 @@ jobs:
             }
           }
           INIT_SCRIPT
+            echo "Using PR-isolated GRADLE_USER_HOME: ${GRADLE_HOME_DIR}"
           else
             mkdir -p "${HOME}/.gradle"
             GRADLE_HOME_DIR="${HOME}/.gradle"
@@ -607,7 +657,8 @@ jobs:
 
       - name: Restore Gradle cache (PR-scoped)
         if: env.PR_CACHE_SCOPE != ''
-        uses: actions/cache@v4
+        id: pr-gradle-cache-web
+        uses: actions/cache/restore@v4
         with:
           path: |
             ${{ env.GRADLE_USER_HOME }}/caches
@@ -635,7 +686,7 @@ jobs:
         if: steps.web_exists.outputs.client_folder_exists == 'true'
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: :${{ steps.web_exists.outputs.modified-arguments-location }}:assembleDist -x preCompileScripts --no-build-cache -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ inputs.push-to-artifactory-cache }} -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }}
+          arguments: :${{ steps.web_exists.outputs.modified-arguments-location }}:assembleDist -x preCompileScripts -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ env.GRADLE_GENESIS_PUSH_TO_CACHE }} -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }} ${{ env.CACHE_OPTS }}
           build-root-directory: "${{ inputs.working-directory }}/"
           cache-disabled: true
 
@@ -645,6 +696,15 @@ jobs:
         run: |
           mv web-distribution-${{ env.RELEASE_VERSION }}.zip ${{ env.REPO_NAME }}-web-${{ env.RELEASE_VERSION }}.zip
           curl -u ${{ secrets.JFROG_USERNAME }}:"${{secrets.JFROG_PASSWORD}}" -X PUT "https://genesisglobal.jfrog.io/artifactory/product/${{ env.REPO_NAME }}/web/" -T *.zip
+
+      - name: Save Gradle cache (PR-scoped)
+        if: always() && env.PR_CACHE_SCOPE != ''
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ${{ env.GRADLE_USER_HOME }}/caches
+            ${{ env.GRADLE_USER_HOME }}/wrapper
+          key: ${{ steps.pr-gradle-cache-web.outputs.cache-primary-key }}
 
       - name: Notify failure on Slack
         uses: youscan/gitactions-slack-notification@3.0.0

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -344,7 +344,7 @@ jobs:
 
       - name: Scan artifact
         if: inputs.jfrogscan
-        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analyis
+        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@workflow_jrog_cache
         with:
           version: ${{ env.RELEASE_VERSION }}
           jfrog-username: ${{ secrets.JFROG_USERNAME }}

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -165,13 +165,13 @@ jobs:
 
       - name: Configure Node
         if: ${{ !inputs.REGISTRY_URL  }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node_version }}
 
       - name: Configure Node if using JFROG npm packages
         if: ${{ inputs.REGISTRY_URL }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node_version }}
           registry-url: ${{ inputs.REGISTRY_URL }}
@@ -240,13 +240,6 @@ jobs:
           sed -E -i "s/^\s{4}version = \".+\"/    version = \"${RELEASE_VERSION}\"/g" ${{ inputs.server-path }}/build.gradle.kts
           sed -E -i "s/^version=.+/version=${RELEASE_VERSION}/g" ${{ inputs.server-path }}/gradle.properties
 
-      - name: Login to Genesis Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: genesisglobal-docker-remote.jfrog.io
-          username: ${{ secrets.JFROG_USERNAME }}
-          password: ${{ secrets.JFROG_PASSWORD }}
-
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
@@ -254,18 +247,6 @@ jobs:
           cache-read-only: ${{ inputs.cache-read-only }}
           cache-write-only: ${{ inputs.cache-write-only }}
           cache-disabled: ${{ inputs.disable-cache }}
-
-      - name: Scan artifact
-        if: inputs.jfrogscan
-        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@develop
-        with:
-          version: ${{ env.RELEASE_VERSION }}
-          jfrog-username: ${{ secrets.JFROG_USERNAME }}
-          jfrog-password: ${{ secrets.JFROG_PASSWORD }}
-          working-directory: ${{ inputs.working-directory }}
-          server-path: ${{ inputs.server-path }}
-          app-name: ${{ inputs.product_name }}
-          build-server-arguments: ${{ inputs.server-build-gradle-arguments }}
 
       - name: Install Sast CLI
         if: inputs.sast
@@ -308,6 +289,20 @@ jobs:
             ${{ inputs.server-build-gradle-arguments }} \
             ${{ env.CACHE_OPTS }}
         working-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
+
+      # Runs after the build so Gradle's appDistZip task finds its outputs already
+      # on disk and completes as UP-TO-DATE, avoiding a second full compilation.
+      - name: Scan artifact
+        if: inputs.jfrogscan
+        uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@github_workflow_analysis
+        with:
+          version: ${{ env.RELEASE_VERSION }}
+          jfrog-username: ${{ secrets.JFROG_USERNAME }}
+          jfrog-password: ${{ secrets.JFROG_PASSWORD }}
+          working-directory: ${{ inputs.working-directory }}
+          server-path: ${{ inputs.server-path }}
+          app-name: ${{ inputs.product_name }}
+          build-server-arguments: ${{ inputs.server-build-gradle-arguments }}
 
       - name: Copy Test Reports
         working-directory: "${{ inputs.working-directory }}"
@@ -424,13 +419,13 @@ jobs:
 
       - name: Configure Node
         if: ${{ !inputs.REGISTRY_URL  }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node_version }}
 
       - name: Configure Node if using JFROG npm packages
         if: ${{ inputs.REGISTRY_URL }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node_version }}
           registry-url: ${{ inputs.REGISTRY_URL }}

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -378,20 +378,8 @@ jobs:
             -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }}
             ${{ inputs.server-build-gradle-arguments }}
 
-      - name: Warm compile cache when dist zip reused (PR-scoped)
-        if: env.PR_CACHE_SCOPE != '' && steps.pr-dist-cache.outputs.cache-hit == 'true'
-        working-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
-        shell: bash
-        run: |
-          ./gradlew classes compileTestKotlin \
-            -Pversion=${{ env.RELEASE_VERSION }} \
-            -PgenesisArtifactoryUser="${{ secrets.JFROG_USERNAME }}" \
-            -PgenesisArtifactoryPassword="${{ secrets.JFROG_PASSWORD }}" \
-            -PpushToCache=false \
-            -PdisableRemoteCache=false \
-            ${{ env.CACHE_OPTS }} \
-            --build-cache \
-            ${{ inputs.server-build-gradle-arguments }}
+      # When dist zip is restored from GHA, Scan skips appDistZip. No warm compile step —
+      # it invalidates test UP-TO-DATE/FROM-CACHE and forces full pbi-app:test on Build.
 
       - name: Server Build
         if: ${{ !inputs.skip-tests }}

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -181,14 +181,6 @@ jobs:
           fetch-depth: '0'
           ref: ${{ inputs.branch }}
 
-      - name: Set dist cache input hash
-        if: env.PR_CACHE_SCOPE != ''
-        working-directory: "${{ inputs.working-directory }}"
-        shell: bash
-        run: |
-          HASH=$( (git ls-files -z "${{ inputs.server-path }}"; git ls-files -z server client 2>/dev/null || true) | sort -zu | git hash-object --stdin)
-          echo "DIST_INPUT_HASH=${HASH}" >> "$GITHUB_ENV"
-
       - name: Configure Node
         if: ${{ !inputs.REGISTRY_URL  }}
         uses: actions/setup-node@v4
@@ -305,10 +297,9 @@ jobs:
           sed -E -i "s/^\s{4}version = \".+\"/    version = \"${RELEASE_VERSION}\"/g" ${{ inputs.server-path }}/build.gradle.kts
           sed -E -i "s/^version=.+/version=${RELEASE_VERSION}/g" ${{ inputs.server-path }}/gradle.properties
 
-      - name: Restore Gradle cache (PR-scoped)
+      - name: Cache Gradle (PR-scoped)
         if: env.PR_CACHE_SCOPE != ''
-        id: pr-gradle-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.GRADLE_USER_HOME }}/caches
@@ -316,16 +307,6 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-${{ hashFiles(format('{0}/gradle.properties', inputs.working-directory), format('{0}/**/gradle-wrapper.properties', inputs.working-directory), format('{0}/{1}/gradle.properties', inputs.working-directory, inputs.server-path), format('{0}/{1}/**/gradle-wrapper.properties', inputs.working-directory, inputs.server-path)) }}
           restore-keys: |
             ${{ runner.os }}-gradle-${{ env.PR_CACHE_SCOPE }}-
-
-      - name: Restore dist zip cache (PR-scoped)
-        if: env.PR_CACHE_SCOPE != ''
-        id: pr-dist-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            ${{ inputs.working-directory }}/server/*/build/dist
-            ${{ inputs.working-directory }}/${{ inputs.server-path }}/*/build/dist
-          key: ${{ runner.os }}-dist-${{ env.PR_CACHE_SCOPE }}-${{ env.DIST_INPUT_HASH }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -376,22 +357,6 @@ jobs:
             ${{ env.CACHE_OPTS }}
             -PpushToCache=${{ env.GRADLE_GENESIS_PUSH_TO_CACHE }}
             -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }}
-            ${{ inputs.server-build-gradle-arguments }}
-
-      # Same-job appDistZip after Scan (May 29 behaviour) when dist zip came from GHA.
-      - name: Prime Gradle via appDistZip when dist zip restored (PR-scoped)
-        if: env.PR_CACHE_SCOPE != '' && steps.pr-dist-cache.outputs.cache-hit == 'true'
-        working-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
-        shell: bash
-        run: |
-          ./gradlew appDistZip \
-            -Pversion=${{ env.RELEASE_VERSION }} \
-            -PgenesisArtifactoryUser="${{ secrets.JFROG_USERNAME }}" \
-            -PgenesisArtifactoryPassword="${{ secrets.JFROG_PASSWORD }}" \
-            -PpushToCache=false \
-            -PdisableRemoteCache=false \
-            ${{ env.CACHE_OPTS }} \
-            --build-cache \
             ${{ inputs.server-build-gradle-arguments }}
 
       - name: Server Build
@@ -447,24 +412,6 @@ jobs:
             ./**/build/test-results/**/*.xml
           fail_on: nothing
           report_suite_logs: any
-
-      - name: Save dist zip cache (PR-scoped)
-        if: always() && env.PR_CACHE_SCOPE != ''
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            ${{ inputs.working-directory }}/server/*/build/dist
-            ${{ inputs.working-directory }}/${{ inputs.server-path }}/*/build/dist
-          key: ${{ runner.os }}-dist-${{ env.PR_CACHE_SCOPE }}-${{ env.DIST_INPUT_HASH }}
-
-      - name: Save Gradle cache (PR-scoped)
-        if: always() && env.PR_CACHE_SCOPE != ''
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            ${{ env.GRADLE_USER_HOME }}/caches
-            ${{ env.GRADLE_USER_HOME }}/wrapper
-          key: ${{ steps.pr-gradle-cache.outputs.cache-primary-key }}
 
       - name: Docker Build Image
         if: inputs.build_docker
@@ -548,14 +495,6 @@ jobs:
         with:
           fetch-depth: '0'
           ref: ${{ inputs.branch }}
-
-      - name: Set dist cache input hash
-        if: env.PR_CACHE_SCOPE != ''
-        working-directory: "${{ inputs.working-directory }}"
-        shell: bash
-        run: |
-          HASH=$( (git ls-files -z "${{ inputs.server-path }}"; git ls-files -z server client 2>/dev/null || true) | sort -zu | git hash-object --stdin)
-          echo "DIST_INPUT_HASH=${HASH}" >> "$GITHUB_ENV"
 
       - name: Configure Node
         if: ${{ !inputs.REGISTRY_URL  }}
@@ -656,10 +595,9 @@ jobs:
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
           sed -E -i "s/^\s{4}version = \".+\"/    version = \"${RELEASE_VERSION}\"/g" ${{ inputs.server-path }}/build.gradle.kts
 
-      - name: Restore Gradle cache (PR-scoped)
+      - name: Cache Gradle (PR-scoped)
         if: env.PR_CACHE_SCOPE != ''
-        id: pr-gradle-cache-web
-        uses: actions/cache/restore@v4
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.GRADLE_USER_HOME }}/caches
@@ -697,15 +635,6 @@ jobs:
         run: |
           mv web-distribution-${{ env.RELEASE_VERSION }}.zip ${{ env.REPO_NAME }}-web-${{ env.RELEASE_VERSION }}.zip
           curl -u ${{ secrets.JFROG_USERNAME }}:"${{secrets.JFROG_PASSWORD}}" -X PUT "https://genesisglobal.jfrog.io/artifactory/product/${{ env.REPO_NAME }}/web/" -T *.zip
-
-      - name: Save Gradle cache (PR-scoped)
-        if: always() && env.PR_CACHE_SCOPE != ''
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            ${{ env.GRADLE_USER_HOME }}/caches
-            ${{ env.GRADLE_USER_HOME }}/wrapper
-          key: ${{ steps.pr-gradle-cache-web.outputs.cache-primary-key }}
 
       - name: Notify failure on Slack
         uses: youscan/gitactions-slack-notification@3.0.0

--- a/.github/workflows/cleanup-pr-cache.yml
+++ b/.github/workflows/cleanup-pr-cache.yml
@@ -1,0 +1,46 @@
+name: Cleanup PR Cache
+
+on:
+  workflow_call:
+    secrets:
+      JFROG_USERNAME:
+        required: true
+      JFROG_PASSWORD:
+        required: true
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Delete GHA cache (PR-scoped)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SCOPE="${{ github.repository_owner }}-${{ github.event.repository.name }}-pr-${{ github.event.pull_request.number }}"
+          echo "Deleting GHA caches with scope: ${SCOPE}"
+          IDS=$(gh cache list --repo ${{ github.repository }} \
+            --key "Linux-gradle-${SCOPE}-" \
+            --json id --jq '.[].id')
+          if [ -z "$IDS" ]; then
+            echo "No GHA cache entries found for this PR."
+          else
+            echo "$IDS" | xargs -r -I{} gh cache delete {} --repo ${{ github.repository }}
+            echo "GHA cache deleted."
+          fi
+
+      - name: Delete Artifactory remote build cache (PR-scoped)
+        run: |
+          SCOPE="${{ github.repository_owner }}-${{ github.event.repository.name }}-pr-${{ github.event.pull_request.number }}"
+          echo "Deleting Artifactory cache for scope: ${SCOPE}"
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -u "${{ secrets.JFROG_USERNAME }}:${{ secrets.JFROG_PASSWORD }}" \
+            -X DELETE "https://genesisglobal.jfrog.io/artifactory/gradle-cache-repo/${SCOPE}/")
+          if [ "$HTTP_STATUS" = "204" ] || [ "$HTTP_STATUS" = "200" ]; then
+            echo "Artifactory cache deleted."
+          elif [ "$HTTP_STATUS" = "404" ]; then
+            echo "No Artifactory cache found for this PR (already clean)."
+          else
+            echo "Artifactory delete returned HTTP ${HTTP_STATUS} - may need manual cleanup."
+          fi

--- a/.github/workflows/cleanup-pr-cache.yml
+++ b/.github/workflows/cleanup-pr-cache.yml
@@ -14,13 +14,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           SCOPE="${{ github.repository_owner }}-${{ github.event.repository.name }}-pr-${{ github.event.pull_request.number }}"
-          echo "Deleting GHA caches with scope: ${SCOPE}"
-          IDS=$(gh cache list --repo ${{ github.repository }} \
-            --key "Linux-gradle-${SCOPE}-" \
-            --json id --jq '.[].id')
+          PREFIX="Linux-gradle-${SCOPE}-"
+          REPO="${{ github.repository }}"
+          echo "Deleting GHA caches with prefix: ${PREFIX}"
+          IDS=$(gh cache list --repo "$REPO" --key "$PREFIX" --json id --jq '.[].id')
           if [ -z "$IDS" ]; then
             echo "No GHA cache entries found for this PR."
           else
-            echo "$IDS" | xargs -r -I{} gh cache delete {} --repo ${{ github.repository }}
+            echo "$IDS" | while read -r id; do
+              [ -n "$id" ] && gh cache delete "$id" --repo "$REPO"
+            done
             echo "GHA cache deleted."
           fi

--- a/.github/workflows/cleanup-pr-cache.yml
+++ b/.github/workflows/cleanup-pr-cache.yml
@@ -2,11 +2,6 @@ name: Cleanup PR Cache
 
 on:
   workflow_call:
-    secrets:
-      JFROG_USERNAME:
-        required: true
-      JFROG_PASSWORD:
-        required: true
 
 jobs:
   cleanup:
@@ -28,19 +23,4 @@ jobs:
           else
             echo "$IDS" | xargs -r -I{} gh cache delete {} --repo ${{ github.repository }}
             echo "GHA cache deleted."
-          fi
-
-      - name: Delete Artifactory remote build cache (PR-scoped)
-        run: |
-          SCOPE="${{ github.repository_owner }}-${{ github.event.repository.name }}-pr-${{ github.event.pull_request.number }}"
-          echo "Deleting Artifactory cache for scope: ${SCOPE}"
-          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            -u "${{ secrets.JFROG_USERNAME }}:${{ secrets.JFROG_PASSWORD }}" \
-            -X DELETE "https://genesisglobal.jfrog.io/artifactory/gradle-cache-repo/${SCOPE}/")
-          if [ "$HTTP_STATUS" = "204" ] || [ "$HTTP_STATUS" = "200" ]; then
-            echo "Artifactory cache deleted."
-          elif [ "$HTTP_STATUS" = "404" ]; then
-            echo "No Artifactory cache found for this PR (already clean)."
-          else
-            echo "Artifactory delete returned HTTP ${HTTP_STATUS} - may need manual cleanup."
           fi

--- a/.github/workflows/pr-title-check-trigger.yaml
+++ b/.github/workflows/pr-title-check-trigger.yaml
@@ -17,4 +17,4 @@ permissions:
 
 jobs:
   check:
-    uses: genesislcap/appdev-workflows/.github/workflows/pr-title-check.yaml@github_workflow_analysis
+    uses: genesislcap/appdev-workflows/.github/workflows/pr-title-check.yaml@github_workflow_analyis

--- a/.github/workflows/pr-title-check-trigger.yaml
+++ b/.github/workflows/pr-title-check-trigger.yaml
@@ -5,12 +5,7 @@ on:
     types:
       - opened
       - edited
-      - synchronize
       - reopened
-
-concurrency:
-  group: pr-title-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
 
 permissions:
   pull-requests: read

--- a/.github/workflows/pr-title-check-trigger.yaml
+++ b/.github/workflows/pr-title-check-trigger.yaml
@@ -17,4 +17,4 @@ permissions:
 
 jobs:
   check:
-    uses: genesislcap/appdev-workflows/.github/workflows/pr-title-check.yaml@github_workflow_analyis
+    uses: genesislcap/appdev-workflows/.github/workflows/pr-title-check.yaml@develop

--- a/.github/workflows/pr-title-check-trigger.yaml
+++ b/.github/workflows/pr-title-check-trigger.yaml
@@ -8,9 +8,13 @@ on:
       - synchronize
       - reopened
 
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: read
 
 jobs:
   check:
-    uses: genesislcap/appdev-workflows/.github/workflows/pr-title-check.yaml@develop
+    uses: genesislcap/appdev-workflows/.github/workflows/pr-title-check.yaml@github_workflow_analysis

--- a/build-image/jfrog-scanning/action.yaml
+++ b/build-image/jfrog-scanning/action.yaml
@@ -24,16 +24,32 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
-
     - uses: jfrog/setup-jfrog-cli@v4
       env:
         JF_URL: https://genesisglobal.jfrog.io
         JF_USER: ${{ inputs.jfrog-username }}
         JF_PASSWORD: ${{ inputs.jfrog-password }}
 
+    - name: Check for existing dist zip
+      id: check_dist
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
+      run: |
+        shopt -s nullglob
+        zips=( */build/dist/*.zip )
+        if [ ${#zips[@]} -gt 0 ]; then
+          echo "dist_exists=true" >> $GITHUB_OUTPUT
+          echo "Reusing existing dist zip(s): ${zips[*]}"
+        else
+          echo "dist_exists=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Setup Gradle
+      if: steps.check_dist.outputs.dist_exists != 'true'
+      uses: gradle/actions/setup-gradle@v4
+
     - name: Check if appDistZip exists
+      if: steps.check_dist.outputs.dist_exists != 'true'
       shell: bash
       id: check_task
       working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
@@ -45,14 +61,14 @@ runs:
         fi
 
     - name: Build the dist
-      if: steps.check_task.outputs.appDistZip == 'true'
+      if: steps.check_task.outputs.appDistZip == 'true' && steps.check_dist.outputs.dist_exists != 'true'
       shell: bash
       working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
       run: |
         ./gradlew appDistZip -Pversion=${{ inputs.version }} -PgenesisArtifactoryUser="${{ inputs.jfrog-username }}" -PgenesisArtifactoryPassword="${{ inputs.jfrog-password }}" --no-daemon ${{ inputs.build-server-arguments }}
 
     - name: Run the JFrog scan
-      if: steps.check_task.outputs.appDistZip == 'true'
+      if: steps.check_dist.outputs.dist_exists == 'true' || steps.check_task.outputs.appDistZip == 'true'
       id: scan
       shell: bash
       working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
@@ -93,20 +109,20 @@ runs:
         echo "table_report_file=$TABLE_REPORT" >> $GITHUB_OUTPUT
 
     - name: Create markdown summary
-      if: steps.check_task.outputs.appDistZip == 'true'
+      if: steps.check_dist.outputs.dist_exists == 'true' || steps.check_task.outputs.appDistZip == 'true'
       uses: genesislcap/appdev-workflows/build-image/json-to-md@github_workflow_analyis
       with:
         json_path: ${{ steps.scan.outputs.full_report_file }}
 
     - name: Upload JFrog full scan report
-      if: steps.check_task.outputs.appDistZip == 'true'
+      if: steps.check_dist.outputs.dist_exists == 'true' || steps.check_task.outputs.appDistZip == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: xray-full-report--${{ inputs.app-name }}-${{ github.run_number }}
         path: ${{ steps.scan.outputs.full_report_file }}
 
     - name: Upload JFrog scan table report
-      if: steps.check_task.outputs.appDistZip == 'true'
+      if: steps.check_dist.outputs.dist_exists == 'true' || steps.check_task.outputs.appDistZip == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: xray-dependencies-scan--${{ inputs.app-name }}-${{ github.run_number }}

--- a/build-image/jfrog-scanning/action.yaml
+++ b/build-image/jfrog-scanning/action.yaml
@@ -34,9 +34,10 @@ runs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
       with:
-        # PR cache: caller restores GRADLE_USER_HOME first — do not overwrite. Direct callers: unchanged.
+        # PR cache: caller owns GRADLE_USER_HOME — disable setup-gradle cache entirely so it cannot
+        # restore its own snapshot on top of the PR-scoped cache we already restored.
+        cache-disabled: ${{ inputs.enable-pr-cache }}
         cache-overwrite-existing: ${{ !inputs.enable-pr-cache }}
-        cache-disabled: false
 
     - uses: jfrog/setup-jfrog-cli@v4
       env:

--- a/build-image/jfrog-scanning/action.yaml
+++ b/build-image/jfrog-scanning/action.yaml
@@ -24,6 +24,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Always warm Gradle cache first (regression fix: was moved after check_dist in 1534d5b).
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+      with:
+        cache-overwrite-existing: true
+        cache-disabled: false
+
     - uses: jfrog/setup-jfrog-cli@v4
       env:
         JF_URL: https://genesisglobal.jfrog.io
@@ -44,17 +51,14 @@ runs:
           echo "dist_exists=false" >> $GITHUB_OUTPUT
         fi
 
-    - name: Setup Gradle
-      if: steps.check_dist.outputs.dist_exists != 'true'
-      uses: gradle/actions/setup-gradle@v4
-
     - name: Check if appDistZip exists
       if: steps.check_dist.outputs.dist_exists != 'true'
       shell: bash
       id: check_task
       working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
       run: |
-        if ./gradlew help --task appDistZip -Pversion=${{ inputs.version }} -PgenesisArtifactoryUser="${{ inputs.jfrog-username }}" -PgenesisArtifactoryPassword="${{ inputs.jfrog-password }}" --no-daemon >/dev/null 2>&1; then
+        GRADLE_PROPS="-Pversion=${{ inputs.version }} -PgenesisArtifactoryUser=${{ inputs.jfrog-username }} -PgenesisArtifactoryPassword=${{ inputs.jfrog-password }}"
+        if ./gradlew tasks --all -q $GRADLE_PROPS 2>/dev/null | grep -q 'appDistZip'; then
           echo "appDistZip=true" >> $GITHUB_OUTPUT
         else
           echo "appDistZip=false" >> $GITHUB_OUTPUT
@@ -65,7 +69,11 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
       run: |
-        ./gradlew appDistZip -Pversion=${{ inputs.version }} -PgenesisArtifactoryUser="${{ inputs.jfrog-username }}" -PgenesisArtifactoryPassword="${{ inputs.jfrog-password }}" --no-daemon ${{ inputs.build-server-arguments }}
+        ./gradlew appDistZip \
+          -Pversion=${{ inputs.version }} \
+          -PgenesisArtifactoryUser="${{ inputs.jfrog-username }}" \
+          -PgenesisArtifactoryPassword="${{ inputs.jfrog-password }}" \
+          ${{ inputs.build-server-arguments }}
 
     - name: Run the JFrog scan
       if: steps.check_dist.outputs.dist_exists == 'true' || steps.check_task.outputs.appDistZip == 'true'

--- a/build-image/jfrog-scanning/action.yaml
+++ b/build-image/jfrog-scanning/action.yaml
@@ -29,7 +29,7 @@ runs:
       uses: gradle/actions/setup-gradle@v4
       with:
         cache-overwrite-existing: true
-        cache-disabled: false
+        cache-disabled: ${{ env.PR_CACHE_SCOPE != '' }}
 
     - uses: jfrog/setup-jfrog-cli@v4
       env:

--- a/build-image/jfrog-scanning/action.yaml
+++ b/build-image/jfrog-scanning/action.yaml
@@ -28,6 +28,7 @@ inputs:
     default: false
 
 runs:
+
   using: "composite"
   steps:
     # Always warm Gradle cache first (regression fix: was moved after check_dist in 1534d5b).
@@ -124,7 +125,7 @@ runs:
 
     - name: Create markdown summary
       if: steps.check_dist.outputs.dist_exists == 'true' || steps.check_task.outputs.appDistZip == 'true'
-      uses: genesislcap/appdev-workflows/build-image/json-to-md@github_workflow_analyis
+      uses: genesislcap/appdev-workflows/build-image/json-to-md@develop
       with:
         json_path: ${{ steps.scan.outputs.full_report_file }}
 

--- a/build-image/jfrog-scanning/action.yaml
+++ b/build-image/jfrog-scanning/action.yaml
@@ -34,10 +34,8 @@ runs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
       with:
-        # PR cache: caller owns GRADLE_USER_HOME — disable setup-gradle cache entirely so it cannot
-        # restore its own snapshot on top of the PR-scoped cache we already restored.
-        cache-disabled: ${{ inputs.enable-pr-cache }}
-        cache-overwrite-existing: ${{ !inputs.enable-pr-cache }}
+        # Preserve existing GRADLE_USER_HOME when PR cache is active; default behavior otherwise.
+        cache-overwrite-existing: ${{ !inputs.enable-pr-cache }} # default value false
 
     - uses: jfrog/setup-jfrog-cli@v4
       env:

--- a/build-image/jfrog-scanning/action.yaml
+++ b/build-image/jfrog-scanning/action.yaml
@@ -20,6 +20,12 @@ inputs:
     required: false
   app-name:
     required: false
+  enable-pr-cache:
+    description: >-
+      When true (caller has set PR-scoped GRADLE_USER_HOME and restored GHA cache), setup-gradle
+      must not overwrite that cache. When false or omitted, keeps legacy scan behavior unchanged.
+    required: false
+    default: false
 
 runs:
   using: "composite"
@@ -28,7 +34,8 @@ runs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
       with:
-        cache-overwrite-existing: true
+        # PR cache: caller restores GRADLE_USER_HOME first — do not overwrite. Direct callers: unchanged.
+        cache-overwrite-existing: ${{ !inputs.enable-pr-cache }}
         cache-disabled: false
 
     - uses: jfrog/setup-jfrog-cli@v4

--- a/build-image/jfrog-scanning/action.yaml
+++ b/build-image/jfrog-scanning/action.yaml
@@ -94,7 +94,7 @@ runs:
 
     - name: Create markdown summary
       if: steps.check_task.outputs.appDistZip == 'true'
-      uses: genesislcap/appdev-workflows/build-image/json-to-md@github_workflow_analysis
+      uses: genesislcap/appdev-workflows/build-image/json-to-md@github_workflow_analyis
       with:
         json_path: ${{ steps.scan.outputs.full_report_file }}
 

--- a/build-image/jfrog-scanning/action.yaml
+++ b/build-image/jfrog-scanning/action.yaml
@@ -29,7 +29,7 @@ runs:
       uses: gradle/actions/setup-gradle@v4
       with:
         cache-overwrite-existing: true
-        cache-disabled: ${{ env.PR_CACHE_SCOPE != '' }}
+        cache-disabled: false
 
     - uses: jfrog/setup-jfrog-cli@v4
       env:

--- a/build-image/jfrog-scanning/action.yaml
+++ b/build-image/jfrog-scanning/action.yaml
@@ -94,7 +94,7 @@ runs:
 
     - name: Create markdown summary
       if: steps.check_task.outputs.appDistZip == 'true'
-      uses: genesislcap/appdev-workflows/build-image/json-to-md@develop
+      uses: genesislcap/appdev-workflows/build-image/json-to-md@github_workflow_analysis
       with:
         json_path: ${{ steps.scan.outputs.full_report_file }}
 


### PR DESCRIPTION
PR builds can opt into PR-scoped Gradle caching so the first run is a full build and later runs on the same PR reuse compiled outputs and skip unchanged tests. Cache is cleaned up when the PR closes.

## What changed & how it works

**build-gradle-g8.yml**
- New `enable-pr-cache` input (opt-in only; push/tag and clients without it behave like develop)
- When enabled on a PR:
  - Uses isolated `GRADLE_USER_HOME` per PR (`{owner}-{repo}-pr-{number}`)
  - Restores/saves GHA cache before and after the build
  - Scan runs `appDistZip` first; Build reuses compiled outputs and runs tests
  - Only changed modules + dependents rebuild; unchanged modules are UP-TO-DATE/FROM-CACHE
- When disabled: `--no-build-cache`, default `~/.gradle`, no restore/save steps — same as develop

**jfrog-scanning/action.yaml**
- Reuses existing dist zip if already on disk → skips redundant `appDistZip`
- `cache-overwrite-existing: false` when PR cache is on → does not overwrite caller’s restored `GRADLE_USER_HOME`
- Passes caller cache flags (`--build-cache`, etc.) into `appDistZip`

**cleanup-pr-cache.yml**
- On PR close/merge, deletes only that PR’s cache:
  - GHA: `Linux-gradle-{owner}-{repo}-pr-{number}-*`

**pr-title-check-trigger.yaml**
- Removed `synchronize` → title check no longer runs on every commit push
- Still runs on PR open, title edit, description edit, and reopen

## Client setup 
```yaml
# exiting workflow that calls build-gradle-g8
enable-pr-cache: ${{ github.event_name == 'pull_request' }}
```
```yaml
#add a new workflow- cleanup-pr-cache.yml

name: Cleanup PR Cache

on:
  pull_request:
    types: [closed]

jobs:
  cleanup:
    uses: genesislcap/appdev-workflows/.github/workflows/cleanup-pr-cache.yml@develop

