### PR TITLE
fix: Increase maxSessionTurns from 25 to 50 (DCD-4856)

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -90,7 +90,7 @@ jobs:
           settings: |-
             {
               "model": {
-                "maxSessionTurns": 25
+                "maxSessionTurns": 50
               },
               "telemetry": {
                 "enabled": true,


### PR DESCRIPTION
Increased maxSessionTurns from 25 to 50. The limit was being reached so wanted to increase it. Allows Gemini to get mroe context in the PR

This is part of ongoing investigation.