### PR TITLE
fix: updated Bearer to use latest(DCD-4886)

### DIFF
--- a/build-image/upload-sast-report/action.yaml
+++ b/build-image/upload-sast-report/action.yaml
@@ -16,7 +16,7 @@ runs:
       working-directory: "${{ inputs.working-directory }}"
       shell: bash
       run: |
-          curl -sfL https://raw.githubusercontent.com/Bearer/bearer/main/contrib/install.sh | sh
+          curl -sfL https://raw.githubusercontent.com/Bearer/bearer/main/contrib/install.sh | sh -s -- latest
           echo "PATH=$PWD/bin:$PATH" >> $GITHUB_ENV
 
     - name: Run sast security scan (text report)   


### PR DESCRIPTION
The Bearer installation script was resolving an empty version value and failing with:
Bearer/bearer crit unable to find ''

Updated the Bearer installation command in build-image/upload-sast-report/action.yml to explicitly install the latest release.