### PR TITLE
fix(build): restore --no-daemon in jfrog-scanning for non-PR-cache builds (DCD-4891)

### DIFF
--- a/build-image/jfrog-scanning/action.yaml
+++ b/build-image/jfrog-scanning/action.yaml
@@ -65,7 +65,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
       run: |
         GRADLE_PROPS="-Pversion=${{ inputs.version }} -PgenesisArtifactoryUser=${{ inputs.jfrog-username }} -PgenesisArtifactoryPassword=${{ inputs.jfrog-password }}"
-        if ./gradlew tasks --all -q $GRADLE_PROPS ${{ inputs.build-server-arguments }} 2>/dev/null | grep -q 'appDistZip'; then
+        if ./gradlew tasks --all -q $GRADLE_PROPS ${{ inputs.build-server-arguments }} ${{ inputs.enable-pr-cache != 'true' && '--no-daemon' || '' }} 2>/dev/null | grep -q 'appDistZip'; then
           echo "appDistZip=true" >> $GITHUB_OUTPUT
         else
           echo "appDistZip=false" >> $GITHUB_OUTPUT
@@ -80,6 +80,7 @@ runs:
           -Pversion=${{ inputs.version }} \
           -PgenesisArtifactoryUser="${{ inputs.jfrog-username }}" \
           -PgenesisArtifactoryPassword="${{ inputs.jfrog-password }}" \
+          ${{ inputs.enable-pr-cache != 'true' && '--no-daemon' || '' }} \
           ${{ inputs.build-server-arguments }}
 
     - name: Run the JFrog scan

--- a/build-image/jfrog-scanning/action.yaml
+++ b/build-image/jfrog-scanning/action.yaml
@@ -65,7 +65,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
       run: |
         GRADLE_PROPS="-Pversion=${{ inputs.version }} -PgenesisArtifactoryUser=${{ inputs.jfrog-username }} -PgenesisArtifactoryPassword=${{ inputs.jfrog-password }}"
-        if ./gradlew tasks --all -q $GRADLE_PROPS 2>/dev/null | grep -q 'appDistZip'; then
+        if ./gradlew tasks --all -q $GRADLE_PROPS ${{ inputs.build-server-arguments }} 2>/dev/null | grep -q 'appDistZip'; then
           echo "appDistZip=true" >> $GITHUB_OUTPUT
         else
           echo "appDistZip=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

The `jfrog-scanning` action leaves a Gradle daemon running after its first step. On heavy builds (`-Xmx8g`) that idle daemon holds several GB for up to 3 hours, which can push the self-hosted runner out of memory and kill it mid-run. It shows up as "The self-hosted runner lost communication with the server" rather than a real build failure. This has been failing the tam2 nightly.

## Cause

#396 (DCD-4835) removed `--no-daemon` from two Gradle calls in `build-image/jfrog-scanning/action.yaml`:

1. The "Check if appDistZip exists" probe (now `./gradlew tasks --all`). It takes no caller arguments, so callers cannot pass `--no-daemon` to it, and it starts a daemon that stays resident.
2. The "Build the dist" (`appDistZip`) step, which now relies on `build-server-arguments`.

The probe runs before the SAST scan and the caller's build, so its leftover daemon stacks on top of every later step. tam2 already passes `--no-daemon` via `server-build-gradle-arguments`, but it never reached the probe.

## Change

`build-image/jfrog-scanning/action.yaml`:

1. Forward `build-server-arguments` to the probe so it matches the `appDistZip` step.
2. Add `--no-daemon` to both pre-build steps when PR cache is off: `${{ inputs.enable-pr-cache != 'true' && '--no-daemon' || '' }}`.

| Caller | enable-pr-cache | Probe + appDistZip |
|---|---|---|
| push / tag / nightly (via build-gradle.yml) | false or unset | adds --no-daemon, no resident daemon |
| PR cache (via build-gradle-g8.yml) | true | unchanged, daemon kept for reuse |

This keeps #396 intact. PR cache still relies on daemon reuse and is untouched, and `build-server-arguments` still controls the scan's Gradle args. Only non-PR-cache builds go back to running without a daemon. The action adds the flag itself rather than relying on each caller to pass it, because a missing flag here is a silent runner OOM rather than a visible failure. tam2's `--no-daemon` (TPD-5240) becomes redundant and can be reverted later.
