### PR TITLE
fix: BUILD_VERSION added for cross pr cache visibility (DCD-4835)

### DIFF
--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -228,7 +228,8 @@ jobs:
           RELEASE_VERSION=$(echo "${{ inputs.version }}" | sed 's/\//-/g')
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
           if [ -n "${{ env.REPO_CACHE_SCOPE }}" ]; then
-            BUILD_VERSION="${{ inputs.cache-base-branch }}"
+            CACHE_BRANCH="${{ inputs.cache-base-branch }}"
+            BUILD_VERSION="${CACHE_BRANCH//\//-}"
           else
             BUILD_VERSION="$RELEASE_VERSION"
           fi

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -227,7 +227,13 @@ jobs:
           fi
           RELEASE_VERSION=$(echo "${{ inputs.version }}" | sed 's/\//-/g')
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
-          sed -E -i "s/^\s{4}version = \".+\"/    version = \"${RELEASE_VERSION}\"/g" server/build.gradle.kts
+          if [ -n "${{ env.REPO_CACHE_SCOPE }}" ]; then
+            BUILD_VERSION="${{ inputs.cache-base-branch }}"
+          else
+            BUILD_VERSION="$RELEASE_VERSION"
+          fi
+          echo "BUILD_VERSION=$BUILD_VERSION" >> $GITHUB_ENV
+          sed -E -i "s/^\s{4}version = \".+\"/    version = \"${BUILD_VERSION}\"/g" server/build.gradle.kts
 
           echo "GENX_BUILD_INFO=${{ github.ref_name }} / $(date -u +'%Y-%m-%d-%H%M%S') / $(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
@@ -268,7 +274,7 @@ jobs:
         if: inputs.jfrogscan
         uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@develop
         with:
-          version: ${{ env.RELEASE_VERSION }}
+          version: ${{ env.BUILD_VERSION }}
           jfrog-username: ${{ secrets.JFROG_USERNAME }}
           jfrog-password: ${{ secrets.JFROG_PASSWORD }}
           working-directory: ${{ inputs.working-directory }}
@@ -309,7 +315,7 @@ jobs:
       - name: Build
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build ${{ env.CACHE_OPTS }} --stacktrace -Pversion=${{ env.RELEASE_VERSION }} -PpushToCache=${{ env.GRADLE_GENESIS_PUSH_TO_CACHE }} -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }} ${{ inputs.server-build-gradle-arguments }}
+          arguments: build ${{ env.CACHE_OPTS }} --stacktrace -Pversion=${{ env.BUILD_VERSION }} -PpushToCache=${{ env.GRADLE_GENESIS_PUSH_TO_CACHE }} -PdisableRemoteCache=${{ env.GRADLE_GENESIS_DISABLE_REMOTE_CACHE }} ${{ inputs.server-build-gradle-arguments }}
           build-root-directory: "${{ inputs.working-directory }}"
           cache-disabled: true
         env:


### PR DESCRIPTION
### Trunk Cache Fix: `BUILD_VERSION`

Develop push saves cache with `-Pversion=develop`, but PR builds read with `-Pversion=2578-merge`. This version mismatch causes test task classpath to differ → cache miss on all test tasks → ~14 min builds.

Fix introduces `BUILD_VERSION` which uses `cache-base-branch` (e.g., `develop`) when cache is active. Both the cache saver (develop push) and reader (PR build) now use the same version → test cache hits → ~1 min.

Flow:
- Develop push: `BUILD_VERSION` and `RELEASE_VERSION` are both `develop` — identical, no change.
- PR builds: Version overridden but `upload: false` — nothing gets published.
- Release builds: Don't match `cache-base-branch` → `BUILD_VERSION` falls back to real version.
- Opt-out (`enable-repo-cache: false`): `BUILD_VERSION` = `RELEASE_VERSION` — zero change.