### PR TITLE
chore: move SonarCloud analysis to shared reusable workflow (DCD-5046)

### DIFF
--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -323,48 +323,6 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
 
-      - name: Test and Coverage
-        if: inputs.sonar_enabled
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: test jacocoTestReport --no-configuration-cache
-          build-root-directory: "${{ inputs.working-directory }}/server"
-          cache-disabled: true
-
-      # Sonar stopped supporting JDK 17 to run scans so this is a temporary workaround to run the scan on java 21
-      # We should look at pulling this out of the pipeline or using the other sonarcloud workflow
-      - name: Stop Java 17 Gradle daemons
-        if: inputs.sonar_enabled
-        working-directory: "${{ inputs.working-directory }}/server"
-        run: ./gradlew --stop
-      
-      - name: Set up JDK 21 for Sonar
-        if: inputs.sonar_enabled
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-      
-      - name: Run Sonar analysis
-        if: inputs.sonar_enabled
-        uses: gradle/gradle-build-action@v2
-        env:
-          SONAR_TOKEN: ${{ secrets.JENKINSGENESIS_SONAR }}
-        with:
-          arguments: >
-            sonar --no-configuration-cache
-            -Dsonar.token=${{ env.SONAR_TOKEN }}
-          build-root-directory: "${{ inputs.working-directory }}/server"
-          cache-disabled: true
-
-      - name: Revert back to JDK ${{ inputs.java_version }}
-        if: inputs.sonar_enabled
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ inputs.java_version }}
-          distribution: 'temurin'
-
-
       - name: Check Auth Permissions task
         id: auth_permissions_task
         shell: bash
@@ -522,6 +480,25 @@ jobs:
           SLACK_TITLE: ✅ Server build for ${{ inputs.product_name }} passed
           SLACK_MESSAGE: The server build for ${{ github.workflow }} passed https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/actions/runs/${{ github.run_id }}
           SLACK_CHANNEL: ${{ env.REPO_NAME }}-build-notifications
+
+  sonar:
+    name: SonarCloud Analysis
+    if: ${{ inputs.sonar_enabled }}
+    uses: ./.github/workflows/sonarcloud.yml
+    with:
+      branch: ${{ inputs.branch }}
+      version: ${{ inputs.version }}
+      server-path: 'server'
+      node_version: ${{ inputs.node_version }}
+      REGISTRY_URL: ${{ inputs.REGISTRY_URL }}
+      SCOPE: ${{ inputs.SCOPE }}
+    secrets:
+      GPR_READ_TOKEN: ${{ secrets.GPR_READ_TOKEN }}
+      GRADLE_PROPERTIES: ${{ secrets.GRADLE_PROPERTIES }}
+      JFROG_USERNAME: ${{ secrets.JFROG_USERNAME }}
+      JFROG_EMAIL: ${{ secrets.JFROG_EMAIL }}
+      JFROG_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
+      JENKINSGENESIS_SONAR: ${{ secrets.JENKINSGENESIS_SONAR }}
 
   tag-jiras:
     needs: build-server

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -488,7 +488,7 @@ jobs:
     with:
       branch: ${{ inputs.branch }}
       version: ${{ inputs.version }}
-      server-path: 'server'
+      server-path: '${{ inputs.working-directory }}/server'
       node_version: ${{ inputs.node_version }}
       REGISTRY_URL: ${{ inputs.REGISTRY_URL }}
       SCOPE: ${{ inputs.SCOPE }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -192,9 +192,15 @@ jobs:
           if [ -n "${GRADLE_PROPERTIES:-}" ]; then
             printf '%s\n' "${GRADLE_PROPERTIES}" >> "${HOME}/.gradle/gradle.properties"
           fi
-          chmod +x ./gradlew
-          chmod +x "./${{ inputs.server-path }}/gradlew"
-          chmod -R +rx "./${{ inputs.server-path }}"
+          if [ -f ./gradlew ]; then
+            chmod +x ./gradlew
+          fi
+          if [ -f "./${{ inputs.server-path }}/gradlew" ]; then
+            chmod +x "./${{ inputs.server-path }}/gradlew"
+          fi
+          if [ -d "./${{ inputs.server-path }}" ]; then
+            chmod -R +rx "./${{ inputs.server-path }}"
+          fi
           cat "${HOME}/.gradle/gradle.properties" >> ./gradle.properties
           RELEASE_VERSION="$(echo '${{ inputs.version }}' | sed 's/\//-/g')"
           BUILD_FILE="${{ inputs.server-path }}/build.gradle.kts"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,4 +1,3 @@
-```yaml
 name: SonarCloud
 
 on:
@@ -8,82 +7,76 @@ on:
         description: Branch or ref to analyse
         required: false
         type: string
-
       version:
         description: Application version
         required: false
         type: string
-
+      working-directory:
+        description: Project working directory
+        required: false
+        type: string
+        default: '.'
       server-path:
         description: Path containing the server Gradle wrapper
         required: false
         type: string
-        default: 'server/jvm'
-
+        default: 'server'
+      project_java_version:
+        description: Java version used to compile and test the application
+        required: false
+        type: string
+        default: '17'
       node_version:
         description: Node.js version required by the project
         required: false
-        default: '16.x'
         type: string
-
+        default: '20.x'
       REGISTRY_URL:
         description: Only used by older versions of Genesis Framework
         required: false
         type: string
-
       SCOPE:
         description: NPM scope used with REGISTRY_URL
         required: false
         type: string
-
     secrets:
       GPR_READ_TOKEN:
         required: true
-
       GRADLE_PROPERTIES:
         required: true
-
       JFROG_USERNAME:
         required: true
-
       JFROG_EMAIL:
         required: true
-
       JFROG_PASSWORD:
         required: true
-
       JENKINSGENESIS_SONAR:
         required: true
 
 env:
   NODE_AUTH_TOKEN: ${{ secrets.GPR_READ_TOKEN }}
+  SONAR_ARTIFACT_NAME: sonar-inputs-${{ github.run_id }}
 
 jobs:
-  build:
-    name: SonarCloud Analysis
+  prepare-analysis:
+    name: Prepare Sonar inputs
     runs-on: [appdev-selfhosted-al2023]
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ inputs.branch }}
-
-      # Java 21 is required only for running the Sonar scanner.
-      # The main application build can continue using Java 17.
-      - name: Set up JDK 21 for Sonar
+      - name: Set up project JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
-
+          java-version: ${{ inputs.project_java_version }}
+          distribution: temurin
       - name: Configure Node
         if: ${{ !inputs.REGISTRY_URL }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node_version }}
-
       - name: Configure Node if using JFrog npm packages
         if: ${{ inputs.REGISTRY_URL }}
         uses: actions/setup-node@v4
@@ -91,18 +84,15 @@ jobs:
           node-version: ${{ inputs.node_version }}
           registry-url: ${{ inputs.REGISTRY_URL }}
           scope: ${{ inputs.SCOPE }}
-
       - name: Restore gradle.properties and setup
+        working-directory: ${{ inputs.working-directory }}
         shell: bash
         env:
           GRADLE_PROPERTIES: ${{ secrets.GRADLE_PROPERTIES }}
         run: |
           set -euo pipefail
-
           mkdir -p "${HOME}/.gradle"
-
           echo "GRADLE_USER_HOME=${HOME}/.gradle" >> "${GITHUB_ENV}"
-
           {
             echo "genesisArtifactoryUser=${{ secrets.JFROG_USERNAME }}"
             echo "genesisArtifactoryPassword=${{ secrets.JFROG_PASSWORD }}"
@@ -115,46 +105,117 @@ jobs:
             echo "genesis-home=../.genesis-home"
             echo "deploy-plugin-mode=local"
           } > "${HOME}/.gradle/gradle.properties"
-
           if [ -n "${GRADLE_PROPERTIES:-}" ]; then
-            printf '%s\n' "${GRADLE_PROPERTIES}" \
-              >> "${HOME}/.gradle/gradle.properties"
+            printf '%s\n' "${GRADLE_PROPERTIES}" >> "${HOME}/.gradle/gradle.properties"
           fi
-
           chmod +x ./gradlew
           chmod +x "./${{ inputs.server-path }}/gradlew"
           chmod -R +rx "./${{ inputs.server-path }}"
-
           cat "${HOME}/.gradle/gradle.properties" >> ./gradle.properties
-
           RELEASE_VERSION="$(echo '${{ inputs.version }}' | sed 's/\//-/g')"
           echo "RELEASE_VERSION=${RELEASE_VERSION}" >> "${GITHUB_ENV}"
-
           BUILD_FILE="${{ inputs.server-path }}/build.gradle.kts"
-
           if [ -n "${RELEASE_VERSION}" ] && [ -f "${BUILD_FILE}" ]; then
-            sed -E -i \
-              "s/^[[:space:]]{4}version = \".+\"/    version = \"${RELEASE_VERSION}\"/g" \
-              "${BUILD_FILE}"
+            sed -E -i "s/^[[:space:]]{4}version = \".+\"/    version = \"${RELEASE_VERSION}\"/g" "${BUILD_FILE}"
           fi
-
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
           cache-disabled: true
+      - name: Run tests and generate coverage
+        working-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./gradlew test jacocoTestReport --no-configuration-cache --stacktrace
+      - name: Upload Sonar inputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.SONAR_ARTIFACT_NAME }}
+          retention-days: 1
+          if-no-files-found: error
+          path: |
+            ${{ inputs.working-directory }}/${{ inputs.server-path }}/**/build/classes/**
+            ${{ inputs.working-directory }}/${{ inputs.server-path }}/**/build/generated/**
+            ${{ inputs.working-directory }}/${{ inputs.server-path }}/**/build/reports/**
+            ${{ inputs.working-directory }}/${{ inputs.server-path }}/**/build/test-results/**
+            ${{ inputs.working-directory }}/${{ inputs.server-path }}/**/build/jacoco/**
 
-      - name: Run tests, coverage and Sonar analysis
-        working-directory: "./${{ inputs.server-path }}"
+  sonar-analysis:
+    name: SonarCloud analysis
+    needs: prepare-analysis
+    runs-on: [appdev-selfhosted-al2023]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.branch }}
+      - name: Set up JDK 21 for Sonar
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: temurin
+      - name: Configure Node
+        if: ${{ !inputs.REGISTRY_URL }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node_version }}
+      - name: Configure Node if using JFrog npm packages
+        if: ${{ inputs.REGISTRY_URL }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node_version }}
+          registry-url: ${{ inputs.REGISTRY_URL }}
+          scope: ${{ inputs.SCOPE }}
+      - name: Restore gradle.properties and setup
+        working-directory: ${{ inputs.working-directory }}
+        shell: bash
+        env:
+          GRADLE_PROPERTIES: ${{ secrets.GRADLE_PROPERTIES }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${HOME}/.gradle"
+          echo "GRADLE_USER_HOME=${HOME}/.gradle" >> "${GITHUB_ENV}"
+          {
+            echo "genesisArtifactoryUser=${{ secrets.JFROG_USERNAME }}"
+            echo "genesisArtifactoryPassword=${{ secrets.JFROG_PASSWORD }}"
+            echo "systemProp.org.gradle.internal.http.connectionTimeout=180000"
+            echo "systemProp.org.gradle.internal.http.socketTimeout=180000"
+            echo "dockerUrl=genesisglobal-docker-internal.jfrog.io"
+            echo "dockerUsername=${{ secrets.JFROG_USERNAME }}"
+            echo "dockerPassword=${{ secrets.JFROG_PASSWORD }}"
+            echo "dockerEmail=${{ secrets.JFROG_EMAIL }}"
+            echo "genesis-home=../.genesis-home"
+            echo "deploy-plugin-mode=local"
+          } > "${HOME}/.gradle/gradle.properties"
+          if [ -n "${GRADLE_PROPERTIES:-}" ]; then
+            printf '%s\n' "${GRADLE_PROPERTIES}" >> "${HOME}/.gradle/gradle.properties"
+          fi
+          chmod +x ./gradlew
+          chmod +x "./${{ inputs.server-path }}/gradlew"
+          chmod -R +rx "./${{ inputs.server-path }}"
+          cat "${HOME}/.gradle/gradle.properties" >> ./gradle.properties
+          RELEASE_VERSION="$(echo '${{ inputs.version }}' | sed 's/\//-/g')"
+          BUILD_FILE="${{ inputs.server-path }}/build.gradle.kts"
+          if [ -n "${RELEASE_VERSION}" ] && [ -f "${BUILD_FILE}" ]; then
+            sed -E -i "s/^[[:space:]]{4}version = \".+\"/    version = \"${RELEASE_VERSION}\"/g" "${BUILD_FILE}"
+          fi
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-disabled: true
+      - name: Download Sonar inputs
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.SONAR_ARTIFACT_NAME }}
+          path: ${{ github.workspace }}
+      - name: Run SonarCloud analysis
+        working-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
         shell: bash
         env:
           SONAR_TOKEN: ${{ secrets.JENKINSGENESIS_SONAR }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-
-          ./gradlew \
-            test \
-            jacocoTestReport \
-            sonar \
-            --no-configuration-cache \
-            -Dsonar.token="${SONAR_TOKEN}"
-```
+          ./gradlew sonar --no-configuration-cache --stacktrace -Dsonar.token="${SONAR_TOKEN}"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,120 +1,160 @@
+```yaml
 name: SonarCloud
+
 on:
   workflow_call:
     inputs:
       branch:
+        description: Branch or ref to analyse
         required: false
         type: string
+
       version:
+        description: Application version
         required: false
         type: string
+
       server-path:
+        description: Path containing the server Gradle wrapper
         required: false
         type: string
         default: 'server/jvm'
-      java_version:
-        required: false
-        default: '11'
-        type: string
+
       node_version:
+        description: Node.js version required by the project
         required: false
         default: '16.x'
         type: string
-      REGISTRY_URL:
-        type: string
-        description: Only used by the older version of genesisframework
-        required: false
-      SCOPE:
-        type: string
-        description: Only used by the older version of genesisframework if SCOPE is used then REGISTRY_URL has to be passed
-        required: false
 
+      REGISTRY_URL:
+        description: Only used by older versions of Genesis Framework
+        required: false
+        type: string
+
+      SCOPE:
+        description: NPM scope used with REGISTRY_URL
+        required: false
+        type: string
 
     secrets:
       GPR_READ_TOKEN:
         required: true
+
       GRADLE_PROPERTIES:
         required: true
+
       JFROG_USERNAME:
         required: true
+
       JFROG_EMAIL:
         required: true
+
       JFROG_PASSWORD:
         required: true
+
       JENKINSGENESIS_SONAR:
         required: true
-env:
-  NODE_AUTH_TOKEN: ${{secrets.GPR_READ_TOKEN}}
 
-# A workflow run is called from the devops appdev-workflow repos
+env:
+  NODE_AUTH_TOKEN: ${{ secrets.GPR_READ_TOKEN }}
+
 jobs:
   build:
-    runs-on: [ appdev-selfhosted-al2023 ]
+    name: SonarCloud Analysis
+    runs-on: [appdev-selfhosted-al2023]
+
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
-          fetch-depth: '0'
+          fetch-depth: 0
           ref: ${{ inputs.branch }}
 
-      - name: Set up JDK
+      # Java 21 is required only for running the Sonar scanner.
+      # The main application build can continue using Java 17.
+      - name: Set up JDK 21 for Sonar
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ inputs.java_version }}
-          distribution: 'adopt'
+          java-version: '21'
+          distribution: 'temurin'
 
       - name: Configure Node
-        if: ${{ !inputs.REGISTRY_URL  }}
-        uses: actions/setup-node@v2
+        if: ${{ !inputs.REGISTRY_URL }}
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node_version }}
 
-      - name: Configure Node if using JFROG npm packages
+      - name: Configure Node if using JFrog npm packages
         if: ${{ inputs.REGISTRY_URL }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node_version }}
           registry-url: ${{ inputs.REGISTRY_URL }}
           scope: ${{ inputs.SCOPE }}
-      
+
       - name: Restore gradle.properties and setup
+        shell: bash
         env:
           GRADLE_PROPERTIES: ${{ secrets.GRADLE_PROPERTIES }}
-        working-directory: "${{ inputs.working-directory }}"
-        shell: bash
         run: |
-          mkdir -p ~/.gradle/
-          echo "GRADLE_USER_HOME=${HOME}/.gradle" >> $GITHUB_ENV
-          echo "genesisArtifactoryUser=${{ secrets.JFROG_USERNAME }}" > ~/.gradle/gradle.properties
-          echo "genesisArtifactoryPassword=${{ secrets.JFROG_PASSWORD }}" >> ~/.gradle/gradle.properties
+          set -euo pipefail
 
-          echo "systemProp.org.gradle.internal.http.connectionTimeout=180000" >> ~/.gradle/gradle.properties
-          echo "systemProp.org.gradle.internal.http.socketTimeout=180000" >> ~/.gradle/gradle.properties
+          mkdir -p "${HOME}/.gradle"
 
-          echo "dockerUrl=genesisglobal-docker-internal.jfrog.io" >> ~/.gradle/gradle.properties
-          echo "dockerUsername=${{ secrets.JFROG_USERNAME }}" >> ~/.gradle/gradle.properties
-          echo "dockerPassword=${{ secrets.JFROG_PASSWORD }}" >> ~/.gradle/gradle.properties
-          echo "dockerEmail=platformmanageteam@genesis.global" >> ~/.gradle/gradle.properties
+          echo "GRADLE_USER_HOME=${HOME}/.gradle" >> "${GITHUB_ENV}"
 
-          echo "genesis-home=../.genesis-home" >> ~/.gradle/gradle.properties
-          echo "deploy-plugin-mode=local" >> ~/.gradle/gradle.properties
-          sudo chmod +x ./gradlew
-          sudo chmod +x ./${{ inputs.server-path }}/gradlew
-          sudo chmod -R +rx ./${{ inputs.server-path }}/
-          cat ~/.gradle/gradle.properties >>  ./gradle.properties
-          if [ -z "${{ inputs.repo-name }}" ]; then
-            echo "REPO_NAME=$(echo '${{ github.event.repository.name }}' | cut -d'-' -f1)" >> $GITHUB_ENV
-          else
-            echo "REPO_NAME=${{ inputs.repo-name }}" >> $GITHUB_ENV
+          {
+            echo "genesisArtifactoryUser=${{ secrets.JFROG_USERNAME }}"
+            echo "genesisArtifactoryPassword=${{ secrets.JFROG_PASSWORD }}"
+            echo "systemProp.org.gradle.internal.http.connectionTimeout=180000"
+            echo "systemProp.org.gradle.internal.http.socketTimeout=180000"
+            echo "dockerUrl=genesisglobal-docker-internal.jfrog.io"
+            echo "dockerUsername=${{ secrets.JFROG_USERNAME }}"
+            echo "dockerPassword=${{ secrets.JFROG_PASSWORD }}"
+            echo "dockerEmail=${{ secrets.JFROG_EMAIL }}"
+            echo "genesis-home=../.genesis-home"
+            echo "deploy-plugin-mode=local"
+          } > "${HOME}/.gradle/gradle.properties"
+
+          if [ -n "${GRADLE_PROPERTIES:-}" ]; then
+            printf '%s\n' "${GRADLE_PROPERTIES}" \
+              >> "${HOME}/.gradle/gradle.properties"
           fi
-          RELEASE_VERSION=$(echo "${{ inputs.version }}" | sed 's/\//-/g')
-          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
-          sed -E -i "s/^\s{4}version = \".+\"/    version = \"${RELEASE_VERSION}\"/g" ${{ inputs.server-path }}/build.gradle.kts
 
-      - name: Server Build
-        uses: gradle/gradle-build-action@v2
+          chmod +x ./gradlew
+          chmod +x "./${{ inputs.server-path }}/gradlew"
+          chmod -R +rx "./${{ inputs.server-path }}"
+
+          cat "${HOME}/.gradle/gradle.properties" >> ./gradle.properties
+
+          RELEASE_VERSION="$(echo '${{ inputs.version }}' | sed 's/\//-/g')"
+          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> "${GITHUB_ENV}"
+
+          BUILD_FILE="${{ inputs.server-path }}/build.gradle.kts"
+
+          if [ -n "${RELEASE_VERSION}" ] && [ -f "${BUILD_FILE}" ]; then
+            sed -E -i \
+              "s/^[[:space:]]{4}version = \".+\"/    version = \"${RELEASE_VERSION}\"/g" \
+              "${BUILD_FILE}"
+          fi
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-disabled: true
+
+      - name: Run tests, coverage and Sonar analysis
+        working-directory: "./${{ inputs.server-path }}"
+        shell: bash
         env:
           SONAR_TOKEN: ${{ secrets.JENKINSGENESIS_SONAR }}
-        with:
-          arguments: test jacocoTestReport sonarqube --no-configuration-cache -Dsonar.token=${{env.SONAR_TOKEN}}
-          build-root-directory: ./${{ inputs.server-path }}
-          cache-disabled: true
+        run: |
+          set -euo pipefail
+
+          ./gradlew \
+            test \
+            jacocoTestReport \
+            sonar \
+            --no-configuration-cache \
+            -Dsonar.token="${SONAR_TOKEN}"
+```


### PR DESCRIPTION
- Moved Sonar analysis into the shared sonarcloud.yml reusable workflow.
- Updated the shared Sonar workflow to use Java 21 explicitly instead of inheriting the application's JDK.
- Replaced the deprecated Gradle sonarqube task with sonar.
- Updated build-gradle-g8.yml to invoke the shared Sonar workflow instead of performing inline Java switching.
- Removed the temporary workaround that stopped Gradle daemons, switched to Java 21, executed Sonar, and switched back to Java 17.
- Kept the main application build on its configured Java version (Java 17).
- Configured Sonar analysis to run as a separate workflow job, allowing it to execute independently of the main build.