### PR TITLE
ci: enable Trivy scanning for PR builds without pushing images (DCD-5066)

### DIFF
--- a/build-image/action.yaml
+++ b/build-image/action.yaml
@@ -211,14 +211,14 @@ runs:
         ./gradlew checkAuthPermissions --no-configuration-cache --build-cache --stacktrace
 
     - name: Build Image
-      if: inputs.push-image == 'true'
+      if: inputs.push-image == 'true' || inputs.trivy-scan == 'true'
       shell: bash
       working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
       run: |
         ./gradlew buildImage -Pversion=${{ inputs.version }} --no-configuration-cache --no-build-cache --stacktrace -PgenesisArtifactoryUser="${{ inputs.jfrog-username }}" -PgenesisArtifactoryPassword="${{ inputs.jfrog-password }}" ${{ inputs.build-image-arguments }}
 
     - name: Trivy Scan
-      if: ${{ inputs.push-image == 'true' && inputs.trivy-scan == 'true' }}
+      if: inputs.trivy-scan == 'true'
       uses: genesislcap/appdev-workflows/build-image/trivy-scanning@develop
       with:
         image-ref: genesis/${{ env.PRODUCT_NAME }}:${{ inputs.version }}

--- a/build-image/jfrog-scanning/action.yaml
+++ b/build-image/jfrog-scanning/action.yaml
@@ -4,41 +4,49 @@ description: Scan the distribution for vulnerabilities and licences
 inputs:
   version:
     required: true
+
   jfrog-username:
     required: true
+
   jfrog-password:
     required: true
+
   working-directory:
     default: .
     required: false
+
   server-path:
     default: server
     required: false
+
   build-server-arguments:
     type: string
     description: Additional arguments/properties to be passed to the appDistZip gradle task
     required: false
+
   app-name:
     required: false
+
   enable-repo-cache:
     description: >-
-      When true (caller has set repo-scoped GRADLE_USER_HOME and restored GHA cache), setup-gradle
-      must not overwrite that cache. When false or omitted, keeps legacy scan behavior unchanged.
+      When true (caller has set repo-scoped GRADLE_USER_HOME and restored GHA cache),
+      setup-gradle must not overwrite that cache. When false or omitted, keeps
+      legacy scan behavior unchanged.
     required: false
     default: false
 
 runs:
-
   using: "composite"
+
   steps:
-    # Always warm Gradle cache first (regression fix: was moved after check_dist in 1534d5b).
+    # Always warm Gradle cache first.
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
       with:
-        # Preserve existing GRADLE_USER_HOME when repo cache is active; default behavior otherwise.
-        cache-overwrite-existing: ${{ !inputs.enable-repo-cache }} # default value false
+        cache-overwrite-existing: ${{ !inputs.enable-repo-cache }}
 
-    - uses: jfrog/setup-jfrog-cli@v4
+    - name: Setup JFrog CLI
+      uses: jfrog/setup-jfrog-cli@v4
       env:
         JF_URL: https://genesisglobal.jfrog.io
         JF_USER: ${{ inputs.jfrog-username }}
@@ -49,26 +57,36 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
       run: |
+        set -euo pipefail
+
         shopt -s nullglob
         zips=( */build/dist/*.zip )
+
         if [ ${#zips[@]} -gt 0 ]; then
-          echo "dist_exists=true" >> $GITHUB_OUTPUT
+          echo "dist_exists=true" >> "$GITHUB_OUTPUT"
           echo "Reusing existing dist zip(s): ${zips[*]}"
         else
-          echo "dist_exists=false" >> $GITHUB_OUTPUT
+          echo "dist_exists=false" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Check if appDistZip exists
       if: steps.check_dist.outputs.dist_exists != 'true'
-      shell: bash
       id: check_task
+      shell: bash
       working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
       run: |
+        set -euo pipefail
+
         GRADLE_PROPS="-Pversion=${{ inputs.version }} -PgenesisArtifactoryUser=${{ inputs.jfrog-username }} -PgenesisArtifactoryPassword=${{ inputs.jfrog-password }}"
-        if ./gradlew tasks --all -q $GRADLE_PROPS ${{ inputs.build-server-arguments }} ${{ inputs.enable-repo-cache != 'true' && '--no-daemon' || '' }} 2>/dev/null | grep -q 'appDistZip'; then
-          echo "appDistZip=true" >> $GITHUB_OUTPUT
+
+        if ./gradlew tasks --all -q \
+          $GRADLE_PROPS \
+          ${{ inputs.build-server-arguments }} \
+          ${{ inputs.enable-repo-cache != 'true' && '--no-daemon' || '' }} \
+          2>/dev/null | grep -q 'appDistZip'; then
+          echo "appDistZip=true" >> "$GITHUB_OUTPUT"
         else
-          echo "appDistZip=false" >> $GITHUB_OUTPUT
+          echo "appDistZip=false" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Build the dist
@@ -76,6 +94,8 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
       run: |
+        set -euo pipefail
+
         ./gradlew appDistZip \
           -Pversion=${{ inputs.version }} \
           -PgenesisArtifactoryUser="${{ inputs.jfrog-username }}" \
@@ -89,11 +109,17 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
       run: |
+        set -euo pipefail
+
         TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
         FULL_REPORT="$GITHUB_WORKSPACE/jfrog-scan-full.json"
         TABLE_REPORT="$GITHUB_WORKSPACE/jfrog-scan-table-${TIMESTAMP}.txt"
 
-        jf s --licenses --vuln --format=json */build/dist/*.zip > "$FULL_REPORT"
+        jf s \
+          --licenses \
+          --vuln \
+          --format=json \
+          */build/dist/*.zip > "$FULL_REPORT"
 
         if ! jq -r '
           def root:
@@ -104,15 +130,25 @@ runs:
             end;
 
           root as $root
-          | (if ($root | type) == "object" then ($root.vulnerabilities // []) else [] end) as $vulns
-          | (["CVE", "Severity", "Component", "Fixed Versions"],
-             ["---", "---", "---", "---"]),
-            ($vulns[]? | [
-              .cves[0]?.cve // "N/A",
-              .severity // "N/A",
-              ((.components | to_entries[0].key) // "N/A"),
-              ((.fixed_versions // []) | join(", "))
-            ])
+          | (
+              if ($root | type) == "object"
+              then ($root.vulnerabilities // [])
+              else []
+              end
+            ) as $vulns
+          | (
+              ["CVE", "Severity", "Component", "Fixed Versions"],
+              ["---", "---", "---", "---"]
+            ),
+            (
+              $vulns[]?
+              | [
+                  .cves[0]?.cve // "N/A",
+                  .severity // "N/A",
+                  ((.components | to_entries[0].key) // "N/A"),
+                  ((.fixed_versions // []) | join(", "))
+                ]
+            )
           | @tsv
         ' "$FULL_REPORT" > "$TABLE_REPORT"; then
           {
@@ -121,8 +157,8 @@ runs:
           } > "$TABLE_REPORT"
         fi
 
-        echo "full_report_file=$FULL_REPORT" >> $GITHUB_OUTPUT
-        echo "table_report_file=$TABLE_REPORT" >> $GITHUB_OUTPUT
+        echo "full_report_file=$FULL_REPORT" >> "$GITHUB_OUTPUT"
+        echo "table_report_file=$TABLE_REPORT" >> "$GITHUB_OUTPUT"
 
     - name: Create markdown summary
       if: steps.check_dist.outputs.dist_exists == 'true' || steps.check_task.outputs.appDistZip == 'true'
@@ -143,3 +179,51 @@ runs:
       with:
         name: xray-dependencies-scan--${{ inputs.app-name }}-${{ github.run_number }}
         path: ${{ steps.scan.outputs.table_report_file }}
+
+    - name: Evaluate JFrog vulnerability threshold
+      if: steps.check_dist.outputs.dist_exists == 'true' || steps.check_task.outputs.appDistZip == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        FULL_REPORT="${{ steps.scan.outputs.full_report_file }}"
+
+        if [ -z "$FULL_REPORT" ] || [ ! -f "$FULL_REPORT" ]; then
+          echo "::error::JFrog scan report was not generated."
+          exit 1
+        fi
+
+        HIGH_CRITICAL_FINDINGS=$(jq -r '
+          def root:
+            if type == "array" then
+              (map(select(type == "object"))[0] // {})
+            else
+              .
+            end;
+
+          root
+          | [
+              (.vulnerabilities // [])[]?
+              | select(
+                  (
+                    (.severity // "")
+                    | ascii_upcase
+                  ) == "HIGH"
+                  or
+                  (
+                    (.severity // "")
+                    | ascii_upcase
+                  ) == "CRITICAL"
+                )
+            ]
+          | length
+        ' "$FULL_REPORT")
+
+        echo "JFrog High/Critical vulnerability count: $HIGH_CRITICAL_FINDINGS"
+
+        if [ "$HIGH_CRITICAL_FINDINGS" -gt 0 ]; then
+          echo "::error::JFrog Xray found $HIGH_CRITICAL_FINDINGS High or Critical vulnerabilities."
+          exit 1
+        fi
+
+        echo "No High or Critical vulnerabilities detected by JFrog Xray."

--- a/build-image/trivy-scanning/action.yaml
+++ b/build-image/trivy-scanning/action.yaml
@@ -5,24 +5,29 @@ inputs:
   image-ref:
     description: Image reference to scan
     required: true
+
   app-name:
     description: Application or product name used in artifact names
     required: false
     default: ""
+
   severity-threshold:
-    description: Comma-separated severities that should fail the build when fail-build is true
+    description: Comma-separated vulnerability severities that should fail the build when fail-build is true
     required: false
     default: "HIGH,CRITICAL"
+
   fail-build:
-    description: Fail the build when findings meet the severity threshold
+    description: Fail the build when vulnerabilities meet the severity threshold
     required: false
     default: false
     type: boolean
+
   license-full:
     description: Enable full license scanning
     required: false
     default: false
     type: boolean
+
   output-dir:
     description: Directory where reports will be written
     required: false
@@ -31,15 +36,19 @@ inputs:
 outputs:
   json_path:
     value: ${{ steps.scan.outputs.json_path }}
+
   html_path:
     value: ${{ steps.scan.outputs.html_path }}
+
   markdown_path:
     value: ${{ steps.scan.outputs.markdown_path }}
+
   threshold_findings:
     value: ${{ steps.gate.outputs.threshold_findings }}
 
 runs:
   using: "composite"
+
   steps:
     - name: Install Trivy
       shell: bash
@@ -62,12 +71,14 @@ runs:
         set -euo pipefail
 
         APP_NAME="${{ inputs.app-name }}"
+
         if [ -z "$APP_NAME" ]; then
           APP_NAME="scan"
         fi
 
         SAFE_APP_NAME="$(printf '%s' "$APP_NAME" | tr ' /' '--' | tr -cd '[:alnum:]._:-')"
         REPORT_DIR="${{ inputs.output-dir }}"
+
         mkdir -p "$REPORT_DIR"
 
         JSON_FILE="$REPORT_DIR/trivy-scan.json"
@@ -92,6 +103,7 @@ runs:
         IMAGE_REF="${{ inputs.image-ref }}"
 
         LICENSE_FULL_FLAG=""
+
         if [ "${{ inputs.license-full }}" = "true" ]; then
           LICENSE_FULL_FLAG="--license-full"
         fi
@@ -122,12 +134,12 @@ runs:
         SEVERITY_THRESHOLD="${{ inputs.severity-threshold }}"
 
         if [ ! -f "$JSON_FILE" ]; then
-          echo "Trivy JSON report not found: $JSON_FILE"
+          echo "::error::Trivy JSON report not found: $JSON_FILE"
           exit 1
         fi
 
         jq_count() {
-          jq -r "$1 | length" "$JSON_FILE" 2>/dev/null || echo 0
+          jq -r "$1 | length" "$JSON_FILE"
         }
 
         CRIT_VULN=$(jq_count '[.Results[]? | .Vulnerabilities[]? | select((.Severity // "" | ascii_upcase) == "CRITICAL")]')
@@ -147,7 +159,7 @@ runs:
         printf '%s\n' "# Trivy Scan Summary" >> "$MD_FILE"
         printf '\n' >> "$MD_FILE"
         printf 'Image: `%s`\n\n' "$IMAGE_REF" >> "$MD_FILE"
-        printf 'Threshold: `%s`\n\n' "$SEVERITY_THRESHOLD" >> "$MD_FILE"
+        printf 'Blocking vulnerability severities: `%s`\n\n' "$SEVERITY_THRESHOLD" >> "$MD_FILE"
         printf '%s\n\n' "---" >> "$MD_FILE"
 
         printf '%s\n\n' "## Vulnerabilities" >> "$MD_FILE"
@@ -193,7 +205,7 @@ runs:
         name: trivy-scan-md--${{ steps.meta.outputs.app_name }}-${{ github.run_number }}
         path: ${{ steps.scan.outputs.markdown_path }}
 
-    - name: Evaluate threshold
+    - name: Evaluate Trivy vulnerability threshold
       id: gate
       shell: bash
       run: |
@@ -201,25 +213,50 @@ runs:
 
         if [ "${{ inputs.fail-build }}" != "true" ]; then
           echo "threshold_findings=0" >> "$GITHUB_OUTPUT"
+          echo "Trivy vulnerability gate is disabled."
           exit 0
         fi
 
         JSON_FILE="${{ steps.scan.outputs.json_path }}"
         SEVERITY_THRESHOLD="${{ inputs.severity-threshold }}"
 
-        THRESHOLD_FINDINGS=$(jq -r --arg severities "$SEVERITY_THRESHOLD" '
-          def allowed:
-            ($severities | split(",") | map(gsub("^\\s+|\\s+$"; "") | ascii_upcase));
-          def matches_threshold:
-            ((.Severity // .severity // "" | ascii_upcase) as $sev
-             | (allowed | index($sev)) != null);
-          ([.Results[]? | .Vulnerabilities[]? | select(matches_threshold)] | length)
-          + ([.Results[]? | .Licenses[]? | select(matches_threshold)] | length)
-        ' "$JSON_FILE" 2>/dev/null || echo 0)
-
-        echo "threshold_findings=$THRESHOLD_FINDINGS" >> "$GITHUB_OUTPUT"
-
-        if [ "$THRESHOLD_FINDINGS" -gt 0 ]; then
-          echo "Trivy found $THRESHOLD_FINDINGS findings at or above severity threshold '$SEVERITY_THRESHOLD'."
+        if [ -z "$JSON_FILE" ] || [ ! -f "$JSON_FILE" ]; then
+          echo "::error::Trivy JSON report was not generated."
           exit 1
         fi
+
+        THRESHOLD_FINDINGS=$(jq -r \
+          --arg severities "$SEVERITY_THRESHOLD" '
+            def allowed:
+              (
+                $severities
+                | split(",")
+                | map(
+                    gsub("^\\s+|\\s+$"; "")
+                    | ascii_upcase
+                  )
+              );
+
+            def matches_threshold:
+              (
+                (.Severity // .severity // "" | ascii_upcase) as $severity
+                | (allowed | index($severity)) != null
+              );
+
+            [
+              .Results[]?
+              | .Vulnerabilities[]?
+              | select(matches_threshold)
+            ]
+            | length
+          ' "$JSON_FILE")
+
+        echo "threshold_findings=$THRESHOLD_FINDINGS" >> "$GITHUB_OUTPUT"
+        echo "Trivy High/Critical vulnerability count: $THRESHOLD_FINDINGS"
+
+        if [ "$THRESHOLD_FINDINGS" -gt 0 ]; then
+          echo "::error::Trivy found $THRESHOLD_FINDINGS vulnerabilities matching threshold '$SEVERITY_THRESHOLD'."
+          exit 1
+        fi
+
+        echo "No vulnerabilities matched Trivy threshold '$SEVERITY_THRESHOLD'."

--- a/build-image/upload-sast-report/action.yaml
+++ b/build-image/upload-sast-report/action.yaml
@@ -1,39 +1,83 @@
-name: Run SAST 
-description: Run SAST and upload results as GH artifact
+name: Run SAST
+description: Run SAST, upload the SARIF report, and fail for High or Critical findings
 
-inputs:  
+inputs:
   working-directory:
     default: .
     required: false
+
   app-name:
     required: true
 
 runs:
   using: "composite"
+
   steps:
-
-    - name: Install SAST CLI      
-      working-directory: "${{ inputs.working-directory }}"
+    - name: Install SAST CLI
+      working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
-          curl -sfL https://raw.githubusercontent.com/Bearer/bearer/main/contrib/install.sh | sh -s -- latest
-          echo "PATH=$PWD/bin:$PATH" >> $GITHUB_ENV
+        set -euo pipefail
 
-    - name: Run sast security scan (text report)   
-      working-directory: "${{ inputs.working-directory }}"
+        curl -sfL https://raw.githubusercontent.com/Bearer/bearer/main/contrib/install.sh \
+          | sh -s -- latest
+
+        echo "$PWD/bin" >> "$GITHUB_PATH"
+
+    - name: Run SAST security scan
+      id: sast_scan
+      working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
+        set -u
+
+        REPORT_FILE="sast-report-${{ inputs.app-name }}-${{ github.run_number }}.sarif"
+
         set +e
-        # --report=security is default, but added for clarity
-        # --exit-code 0 => never fail the job even if findings exist
-        bearer scan . --report=security --exit-code 0 | tee sast-report-${{ inputs.app-name }}-${{ github.run_number }}.sarif
+
+        bearer scan . \
+          --scanner sast \
+          --report security \
+          --format sarif \
+          --output "$REPORT_FILE" \
+          --severity critical,high,medium,low,warning \
+          --fail-on-severity critical,high \
+          --exit-code 1
+
+        SCAN_EXIT_CODE=$?
+
         set -e
 
+        echo "report_file=$REPORT_FILE" >> "$GITHUB_OUTPUT"
+        echo "scan_exit_code=$SCAN_EXIT_CODE" >> "$GITHUB_OUTPUT"
 
-    - name: Upload sast Security Report     
-      uses: actions/upload-artifact@v4        
+        # Allow report upload before failing the gate.
+        exit 0
+
+    - name: Upload SAST security report
+      if: always()
+      uses: actions/upload-artifact@v4
       with:
         name: sast-report-${{ inputs.app-name }}-${{ github.run_number }}
-        path: sast-report-${{ inputs.app-name }}-${{ github.run_number }}.sarif
+        path: ${{ steps.sast_scan.outputs.report_file }}
+        if-no-files-found: error
 
-    
+    - name: Evaluate SAST vulnerability threshold
+      if: always()
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        SCAN_EXIT_CODE="${{ steps.sast_scan.outputs.scan_exit_code }}"
+
+        if [ -z "$SCAN_EXIT_CODE" ]; then
+          echo "::error::SAST scan did not complete successfully."
+          exit 1
+        fi
+
+        if [ "$SCAN_EXIT_CODE" -ne 0 ]; then
+          echo "::error::SAST found High or Critical security findings."
+          exit 1
+        fi
+
+        echo "No High or Critical SAST findings detected."


### PR DESCRIPTION
Enable Trivy scanning during PR builds by allowing the Docker image to be built locally without pushing it to ECR.

### Changes
- Build the image when `trivy-scan` is enabled.
- Run Trivy scan for PR builds.
- Keep image push behaviour unchanged.