### PR TITLE
ci: make security scan failures opt-in per application

### DIFF
--- a/build-image/action.yaml
+++ b/build-image/action.yaml
@@ -4,93 +4,121 @@ description: Builds a Genesis Docker image
 inputs:
   ecr-registry:
     required: true
+
   version:
     required: true
+
   region:
     required: true
+
   working-directory:
     required: false
     default: "."
+
   aws-access-key-id:
     required: true
+
   aws-secret-access-key:
     required: true
+
   jfrog-username:
     required: true
+
   jfrog-password:
     required: true
+
   app-name:
     required: true
+
   config-path:
     required: false
+
   node-version:
     required: false
     default: "20"
+
   server-path:
     required: false
     default: "server"
+
   test-reports-suffix:
     required: false
     default: ""
+
   push-image:
     required: false
     default: "true"
+
   sast:
+    description: Run the Bearer SAST scan
     required: false
-    default: true
-    type: boolean
+    default: "true"
+
+  jfrogscan:
+    description: Run the JFrog Xray dependency scan
+    required: false
+    default: "true"
+
+  trivy-scan:
+    description: Run the Trivy container image scan
+    required: false
+    default: "false"
+
+  security-fail-build:
+    description: Fail the workflow when security scans find High or Critical vulnerabilities
+    required: false
+    default: "false"
+
+  # Retained for backward compatibility.
+  # Prefer using security-fail-build for new callers.
+  trivy-fail-build:
+    description: Fail specifically for Trivy findings
+    required: false
+    default: "false"
+
+  trivy-license-full:
+    description: Enable full Trivy license scanning
+    required: false
+    default: "false"
+
+  trivy-severity-threshold:
+    description: Comma-separated Trivy severities that should fail the workflow
+    required: false
+    default: "HIGH,CRITICAL"
+
   build-image-arguments:
-    type: string
-    description: Additional arguments/properties to be passed to the buildImage gradle command
+    description: Additional arguments/properties passed to the buildImage Gradle command
     required: false
+    default: ""
+
   skip-tests:
     required: false
-    type: boolean
-    default: false
+    default: "false"
+
   sonar-token:
     required: false
 
-  jfrogscan:
-        required: false
-        default: true
-        type: boolean
-
   sonar-enabled:
     required: false
-    type: boolean
-    default: false
-  trivy-scan:
-    required: false
-    type: boolean
-    default: false
-  trivy-fail-build:
-    required: false
-    type: boolean
-    default: false
-  trivy-license-full:
-    required: false
-    type: boolean
-    default: false
-  trivy-severity-threshold:
-    required: false
-    type: string
-    default: "HIGH,CRITICAL"
+    default: "false"
+
   JENKINSGENESIS_SONAR:
     required: false
 
-
 runs:
-  using: "composite"
+  using: composite
+
   steps:
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        java-version: 17
-        distribution: 'adopt'
+        java-version: "17"
+        distribution: adopt
 
     - name: Install lmdb-devel
       shell: bash
       run: |
+        set -euo pipefail
         sudo dnf install -y lmdb-devel
 
     - name: Configure Node
@@ -103,61 +131,88 @@ runs:
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
-        aws-region: eu-west-2
+        aws-region: ${{ inputs.region }}
 
     - name: Log into ECR
       if: inputs.push-image == 'true'
       shell: bash
       run: |
-        aws ecr get-login-password --region ${{ inputs.region }} | docker login --username AWS --password-stdin ${{ inputs.ecr-registry }}
+        set -euo pipefail
 
-    - name: Login to Jfrog
+        aws ecr get-login-password \
+          --region "${{ inputs.region }}" |
+          docker login \
+            --username AWS \
+            --password-stdin "${{ inputs.ecr-registry }}"
+
+    - name: Login to JFrog
       uses: docker/login-action@v3
       with:
         registry: genesisglobal-docker-remote.jfrog.io
         username: ${{ inputs.jfrog-username }}
         password: ${{ inputs.jfrog-password }}
 
-    - name: Docker iamge preload
+    - name: Docker image preload
       shell: bash
       run: |
+        set -euo pipefail
+
         docker pull genesisglobal-docker-remote.jfrog.io/rockylinux:8-minimal
-        docker tag genesisglobal-docker-remote.jfrog.io/rockylinux:8-minimal rockylinux:8-minimal
+
+        docker tag \
+          genesisglobal-docker-remote.jfrog.io/rockylinux:8-minimal \
+          rockylinux:8-minimal
 
     - name: Set the version
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
-        sed -E -i "s/^\s{4}version = \".+\"/    version = \"${{ inputs.version }}\"/g" ${{ inputs.server-path }}/build.gradle.kts
+        set -euo pipefail
+
+        sed -E -i \
+          "s/^[[:space:]]{4}version = \".+\"/    version = \"${{ inputs.version }}\"/g" \
+          "${{ inputs.server-path }}/build.gradle.kts"
 
     - name: Find product name
       id: find-app-build-type
       shell: bash
+      working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}
       run: |
-        # sensible to customization
-        project_name=$(egrep "(rootProject|productName)" settings.gradle.kts | sed -n -E 's/.*(genesisproduct-|productName *= *")([^"]+)".*/\2/p' | head -n 1)
+        set -euo pipefail
 
-        echo "PRODUCT_NAME=${project_name}" >> $GITHUB_ENV
-      working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
+        project_name="$(
+          grep -E "(rootProject|productName)" settings.gradle.kts |
+          sed -n -E 's/.*(genesisproduct-|productName *= *")([^"]+)".*/\2/p' |
+          head -n 1
+        )"
+
+        if [ -z "$project_name" ]; then
+          echo "::error::Unable to determine PRODUCT_NAME from settings.gradle.kts"
+          exit 1
+        fi
+
+        echo "PRODUCT_NAME=$project_name" >> "$GITHUB_ENV"
+        echo "Detected product name: $project_name"
 
     - name: Read .env file for build
-      if: ${{ inputs.config-path }}
+      if: inputs.config-path != ''
       uses: genesislcap/appdev-workflows/read-dot-env@develop
       with:
         config-path: ${{ inputs.config-path }}
 
-    - name: Run sast report
-      if: inputs.sast
+    - name: Run SAST report
+      if: inputs.sast == 'true'
       uses: genesislcap/appdev-workflows/build-image/upload-sast-report@develop
       with:
         working-directory: ${{ inputs.working-directory }}
         app-name: ${{ inputs.app-name }}
+        fail-build: ${{ inputs.security-fail-build }}
 
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
 
-    - name: Scan artifact
-      if: ${{ inputs.jfrogscan == 'true' }}
+    - name: Scan artifact with JFrog
+      if: inputs.jfrogscan == 'true'
       uses: genesislcap/appdev-workflows/build-image/jfrog-scanning@develop
       with:
         version: ${{ inputs.version }}
@@ -167,9 +222,10 @@ runs:
         server-path: ${{ inputs.server-path }}
         build-server-arguments: ${{ inputs.build-image-arguments }}
         app-name: ${{ inputs.app-name }}
+        fail-build: ${{ inputs.security-fail-build }}
 
     - name: Run Tests
-      if: ${{ inputs.skip-tests != 'true' && inputs.sonar-enabled != 'true' }}
+      if: inputs.skip-tests != 'true' && inputs.sonar-enabled != 'true'
       uses: genesislcap/appdev-workflows/build-image/run-tests@develop
       with:
         version: ${{ inputs.version }}
@@ -180,7 +236,7 @@ runs:
         server-path: ${{ inputs.server-path }}
 
     - name: Run Sonar and Upload Coverage
-      if: ${{ inputs.skip-tests != 'true' && inputs.sonar-enabled == 'true' }}
+      if: inputs.skip-tests != 'true' && inputs.sonar-enabled == 'true'
       uses: genesislcap/appdev-workflows/build-image/upload-test-coverage@develop
       with:
         version: ${{ inputs.version }}
@@ -194,9 +250,14 @@ runs:
     - name: Check Auth Permissions task
       id: auth_permissions_task
       shell: bash
-      working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
+      working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}
       run: |
-        if ./gradlew help --task checkAuthPermissions --no-configuration-cache --quiet >/dev/null 2>&1; then
+        set -euo pipefail
+
+        if ./gradlew help \
+          --task checkAuthPermissions \
+          --no-configuration-cache \
+          --quiet >/dev/null 2>&1; then
           echo "exists=true" >> "$GITHUB_OUTPUT"
         else
           echo "exists=false" >> "$GITHUB_OUTPUT"
@@ -206,16 +267,30 @@ runs:
       id: check_auth_permissions
       if: steps.auth_permissions_task.outputs.exists == 'true'
       shell: bash
-      working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
+      working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}
       run: |
-        ./gradlew checkAuthPermissions --no-configuration-cache --build-cache --stacktrace
+        set -euo pipefail
+
+        ./gradlew checkAuthPermissions \
+          --no-configuration-cache \
+          --build-cache \
+          --stacktrace
 
     - name: Build Image
       if: inputs.push-image == 'true' || inputs.trivy-scan == 'true'
       shell: bash
-      working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
+      working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}
       run: |
-        ./gradlew buildImage -Pversion=${{ inputs.version }} --no-configuration-cache --no-build-cache --stacktrace -PgenesisArtifactoryUser="${{ inputs.jfrog-username }}" -PgenesisArtifactoryPassword="${{ inputs.jfrog-password }}" ${{ inputs.build-image-arguments }}
+        set -euo pipefail
+
+        ./gradlew buildImage \
+          -Pversion="${{ inputs.version }}" \
+          --no-configuration-cache \
+          --no-build-cache \
+          --stacktrace \
+          -PgenesisArtifactoryUser="${{ inputs.jfrog-username }}" \
+          -PgenesisArtifactoryPassword="${{ inputs.jfrog-password }}" \
+          ${{ inputs.build-image-arguments }}
 
     - name: Trivy Scan
       if: inputs.trivy-scan == 'true'
@@ -224,19 +299,19 @@ runs:
         image-ref: genesis/${{ env.PRODUCT_NAME }}:${{ inputs.version }}
         app-name: ${{ inputs.app-name }}
         severity-threshold: ${{ inputs.trivy-severity-threshold }}
-        fail-build: ${{ inputs.trivy-fail-build }}
+        fail-build: ${{ inputs.security-fail-build == 'true' || inputs.trivy-fail-build == 'true' }}
         license-full: ${{ inputs.trivy-license-full }}
         output-dir: ${{ inputs.working-directory }}/trivy-reports
 
     - name: Upload Genesis security permissions report
-      uses: actions/upload-artifact@v4
       if: always() && steps.check_auth_permissions.outcome == 'success'
+      uses: actions/upload-artifact@v4
       with:
         name: genesis-security-permissions-report-${{ inputs.app-name }}-${{ github.run_number }}
-        path: "${{ inputs.working-directory }}/${{ inputs.server-path }}/*/build/reports/genesis-security/auth-permissions.csv"
+        path: ${{ inputs.working-directory }}/${{ inputs.server-path }}/*/build/reports/genesis-security/auth-permissions.csv
         if-no-files-found: ignore
 
-    - name: Push Image using bash
+    - name: Push Image
       if: inputs.push-image == 'true'
       shell: bash
       env:
@@ -244,5 +319,10 @@ runs:
         IMAGE_VERSION: ${{ inputs.version }}
         APP_NAME: ${{ inputs.app-name }}
       run: |
-        docker tag genesis/${PRODUCT_NAME}:${IMAGE_VERSION} ${ECR_REGISTRY}/${APP_NAME}:${IMAGE_VERSION}
-        docker push ${ECR_REGISTRY}/${APP_NAME}:${IMAGE_VERSION}
+        set -euo pipefail
+
+        docker tag \
+          "genesis/${PRODUCT_NAME}:${IMAGE_VERSION}" \
+          "${ECR_REGISTRY}/${APP_NAME}:${IMAGE_VERSION}"
+
+        docker push "${ECR_REGISTRY}/${APP_NAME}:${IMAGE_VERSION}"

--- a/build-image/jfrog-scanning/action.yaml
+++ b/build-image/jfrog-scanning/action.yaml
@@ -12,38 +12,40 @@ inputs:
     required: true
 
   working-directory:
-    default: .
     required: false
+    default: "."
 
   server-path:
-    default: server
     required: false
+    default: "server"
 
   build-server-arguments:
-    type: string
-    description: Additional arguments/properties to be passed to the appDistZip gradle task
+    description: Additional arguments/properties passed to the appDistZip Gradle task
     required: false
+    default: ""
 
   app-name:
     required: false
+    default: ""
 
   enable-repo-cache:
-    description: >-
-      When true (caller has set repo-scoped GRADLE_USER_HOME and restored GHA cache),
-      setup-gradle must not overwrite that cache. When false or omitted, keeps
-      legacy scan behavior unchanged.
+    description: Preserve a repository-scoped Gradle cache when enabled
     required: false
-    default: false
+    default: "false"
+
+  fail-build:
+    description: Fail the workflow when JFrog finds High or Critical vulnerabilities
+    required: false
+    default: "false"
 
 runs:
-  using: "composite"
+  using: composite
 
   steps:
-    # Always warm Gradle cache first.
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
       with:
-        cache-overwrite-existing: ${{ !inputs.enable-repo-cache }}
+        cache-overwrite-existing: ${{ inputs.enable-repo-cache != 'true' }}
 
     - name: Setup JFrog CLI
       uses: jfrog/setup-jfrog-cli@v4
@@ -55,105 +57,130 @@ runs:
     - name: Check for existing dist zip
       id: check_dist
       shell: bash
-      working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
+      working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}
       run: |
         set -euo pipefail
 
         shopt -s nullglob
-        zips=( */build/dist/*.zip )
+        zips=(*/build/dist/*.zip)
 
-        if [ ${#zips[@]} -gt 0 ]; then
+        if [ "${#zips[@]}" -gt 0 ]; then
           echo "dist_exists=true" >> "$GITHUB_OUTPUT"
-          echo "Reusing existing dist zip(s): ${zips[*]}"
+          echo "Reusing existing dist ZIP files:"
+          printf ' - %s\n' "${zips[@]}"
         else
           echo "dist_exists=false" >> "$GITHUB_OUTPUT"
+          echo "No existing dist ZIP found."
         fi
 
     - name: Check if appDistZip exists
       if: steps.check_dist.outputs.dist_exists != 'true'
       id: check_task
       shell: bash
-      working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
+      working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}
       run: |
         set -euo pipefail
 
-        GRADLE_PROPS="-Pversion=${{ inputs.version }} -PgenesisArtifactoryUser=${{ inputs.jfrog-username }} -PgenesisArtifactoryPassword=${{ inputs.jfrog-password }}"
+        gradle_args=(
+          "-Pversion=${{ inputs.version }}"
+          "-PgenesisArtifactoryUser=${{ inputs.jfrog-username }}"
+          "-PgenesisArtifactoryPassword=${{ inputs.jfrog-password }}"
+        )
+
+        if [ "${{ inputs.enable-repo-cache }}" != "true" ]; then
+          gradle_args+=("--no-daemon")
+        fi
 
         if ./gradlew tasks --all -q \
-          $GRADLE_PROPS \
+          "${gradle_args[@]}" \
           ${{ inputs.build-server-arguments }} \
-          ${{ inputs.enable-repo-cache != 'true' && '--no-daemon' || '' }} \
-          2>/dev/null | grep -q 'appDistZip'; then
+          2>/dev/null |
+          grep -qE '(^|[[:space:]])appDistZip([[:space:]]|$)'; then
           echo "appDistZip=true" >> "$GITHUB_OUTPUT"
+          echo "appDistZip task is available."
         else
           echo "appDistZip=false" >> "$GITHUB_OUTPUT"
+          echo "::warning::appDistZip task is not available."
         fi
 
     - name: Build the dist
       if: steps.check_task.outputs.appDistZip == 'true' && steps.check_dist.outputs.dist_exists != 'true'
       shell: bash
-      working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
+      working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}
       run: |
         set -euo pipefail
 
-        ./gradlew appDistZip \
-          -Pversion=${{ inputs.version }} \
-          -PgenesisArtifactoryUser="${{ inputs.jfrog-username }}" \
-          -PgenesisArtifactoryPassword="${{ inputs.jfrog-password }}" \
-          ${{ inputs.enable-repo-cache != 'true' && '--no-daemon' || '' }} \
+        gradle_args=(
+          "appDistZip"
+          "-Pversion=${{ inputs.version }}"
+          "-PgenesisArtifactoryUser=${{ inputs.jfrog-username }}"
+          "-PgenesisArtifactoryPassword=${{ inputs.jfrog-password }}"
+        )
+
+        if [ "${{ inputs.enable-repo-cache }}" != "true" ]; then
+          gradle_args+=("--no-daemon")
+        fi
+
+        ./gradlew \
+          "${gradle_args[@]}" \
           ${{ inputs.build-server-arguments }}
 
     - name: Run the JFrog scan
       if: steps.check_dist.outputs.dist_exists == 'true' || steps.check_task.outputs.appDistZip == 'true'
       id: scan
       shell: bash
-      working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
+      working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}
       run: |
         set -euo pipefail
 
-        TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
+        TIMESTAMP="$(date +"%Y-%m-%d_%H-%M-%S")"
         FULL_REPORT="$GITHUB_WORKSPACE/jfrog-scan-full.json"
         TABLE_REPORT="$GITHUB_WORKSPACE/jfrog-scan-table-${TIMESTAMP}.txt"
+
+        shopt -s nullglob
+        zips=(*/build/dist/*.zip)
+
+        if [ "${#zips[@]}" -eq 0 ]; then
+          echo "::error::No distribution ZIP files were found for JFrog scanning."
+          exit 1
+        fi
 
         jf s \
           --licenses \
           --vuln \
           --format=json \
-          */build/dist/*.zip > "$FULL_REPORT"
+          "${zips[@]}" > "$FULL_REPORT"
 
         if ! jq -r '
-          def root:
+          def roots:
             if type == "array" then
-              (map(select(type == "object"))[0] // {})
-            else
+              .[]
+              | select(type == "object")
+            elif type == "object" then
               .
+            else
+              empty
             end;
 
-          root as $root
-          | (
-              if ($root | type) == "object"
-              then ($root.vulnerabilities // [])
-              else []
-              end
-            ) as $vulns
-          | (
-              ["CVE", "Severity", "Component", "Fixed Versions"],
-              ["---", "---", "---", "---"]
-            ),
-            (
-              $vulns[]?
-              | [
-                  .cves[0]?.cve // "N/A",
-                  .severity // "N/A",
-                  ((.components | to_entries[0].key) // "N/A"),
-                  ((.fixed_versions // []) | join(", "))
-                ]
-            )
+          (
+            ["CVE", "Severity", "Component", "Fixed Versions"],
+            ["---", "---", "---", "---"]
+          ),
+          (
+            roots
+            | (.vulnerabilities // [])[]?
+            | [
+                (.cves[0]?.cve // "N/A"),
+                (.severity // "N/A"),
+                ((.components // {}) | to_entries[0]?.key // "N/A"),
+                ((.fixed_versions // []) | join(", "))
+              ]
+          )
           | @tsv
         ' "$FULL_REPORT" > "$TABLE_REPORT"; then
           {
-            echo -e "CVE\tSeverity\tComponent\tFixed Versions"
-            echo -e "---\t---\t---\t---"
+            printf 'CVE\tSeverity\tComponent\tFixed Versions\n'
+            printf '%s\n' '---	---	---	---'
           } > "$TABLE_REPORT"
         fi
 
@@ -161,69 +188,76 @@ runs:
         echo "table_report_file=$TABLE_REPORT" >> "$GITHUB_OUTPUT"
 
     - name: Create markdown summary
-      if: steps.check_dist.outputs.dist_exists == 'true' || steps.check_task.outputs.appDistZip == 'true'
+      if: steps.scan.outcome == 'success'
       uses: genesislcap/appdev-workflows/build-image/json-to-md@develop
       with:
         json_path: ${{ steps.scan.outputs.full_report_file }}
 
     - name: Upload JFrog full scan report
-      if: steps.check_dist.outputs.dist_exists == 'true' || steps.check_task.outputs.appDistZip == 'true'
+      if: always() && steps.scan.outputs.full_report_file != ''
       uses: actions/upload-artifact@v4
       with:
         name: xray-full-report--${{ inputs.app-name }}-${{ github.run_number }}
         path: ${{ steps.scan.outputs.full_report_file }}
+        if-no-files-found: error
 
     - name: Upload JFrog scan table report
-      if: steps.check_dist.outputs.dist_exists == 'true' || steps.check_task.outputs.appDistZip == 'true'
+      if: always() && steps.scan.outputs.table_report_file != ''
       uses: actions/upload-artifact@v4
       with:
         name: xray-dependencies-scan--${{ inputs.app-name }}-${{ github.run_number }}
         path: ${{ steps.scan.outputs.table_report_file }}
+        if-no-files-found: error
 
     - name: Evaluate JFrog vulnerability threshold
-      if: steps.check_dist.outputs.dist_exists == 'true' || steps.check_task.outputs.appDistZip == 'true'
+      if: steps.scan.outcome == 'success'
       shell: bash
       run: |
         set -euo pipefail
 
         FULL_REPORT="${{ steps.scan.outputs.full_report_file }}"
+        FAIL_BUILD="${{ inputs.fail-build }}"
 
         if [ -z "$FULL_REPORT" ] || [ ! -f "$FULL_REPORT" ]; then
           echo "::error::JFrog scan report was not generated."
           exit 1
         fi
 
-        HIGH_CRITICAL_FINDINGS=$(jq -r '
-          def root:
-            if type == "array" then
-              (map(select(type == "object"))[0] // {})
-            else
-              .
-            end;
+        HIGH_CRITICAL_FINDINGS="$(
+          jq -r '
+            def roots:
+              if type == "array" then
+                .[]
+                | select(type == "object")
+              elif type == "object" then
+                .
+              else
+                empty
+              end;
 
-          root
-          | [
-              (.vulnerabilities // [])[]?
+            [
+              roots
+              | (.vulnerabilities // [])[]?
               | select(
-                  (
-                    (.severity // "")
-                    | ascii_upcase
-                  ) == "HIGH"
+                  ((.severity // "") | ascii_upcase) == "HIGH"
                   or
-                  (
-                    (.severity // "")
-                    | ascii_upcase
-                  ) == "CRITICAL"
+                  ((.severity // "") | ascii_upcase) == "CRITICAL"
                 )
             ]
-          | length
-        ' "$FULL_REPORT")
+            | length
+          ' "$FULL_REPORT"
+        )"
 
         echo "JFrog High/Critical vulnerability count: $HIGH_CRITICAL_FINDINGS"
 
         if [ "$HIGH_CRITICAL_FINDINGS" -gt 0 ]; then
-          echo "::error::JFrog Xray found $HIGH_CRITICAL_FINDINGS High or Critical vulnerabilities."
-          exit 1
+          if [ "$FAIL_BUILD" = "true" ]; then
+            echo "::error::JFrog Xray found $HIGH_CRITICAL_FINDINGS High or Critical vulnerabilities."
+            exit 1
+          fi
+
+          echo "::warning::JFrog Xray found $HIGH_CRITICAL_FINDINGS High or Critical vulnerabilities. Blocking is disabled for this application."
+          exit 0
         fi
 
         echo "No High or Critical vulnerabilities detected by JFrog Xray."

--- a/build-image/trivy-scanning/action.yaml
+++ b/build-image/trivy-scanning/action.yaml
@@ -12,21 +12,19 @@ inputs:
     default: ""
 
   severity-threshold:
-    description: Comma-separated vulnerability severities that should fail the build when fail-build is true
+    description: Comma-separated vulnerability severities that should fail the build
     required: false
     default: "HIGH,CRITICAL"
 
   fail-build:
     description: Fail the build when vulnerabilities meet the severity threshold
     required: false
-    default: false
-    type: boolean
+    default: "false"
 
   license-full:
     description: Enable full license scanning
     required: false
-    default: false
-    type: boolean
+    default: "false"
 
   output-dir:
     description: Directory where reports will be written
@@ -35,19 +33,23 @@ inputs:
 
 outputs:
   json_path:
+    description: Path to the Trivy JSON report
     value: ${{ steps.scan.outputs.json_path }}
 
   html_path:
+    description: Path to the Trivy HTML report
     value: ${{ steps.scan.outputs.html_path }}
 
   markdown_path:
+    description: Path to the Trivy Markdown report
     value: ${{ steps.scan.outputs.markdown_path }}
 
   threshold_findings:
+    description: Number of vulnerabilities matching the configured threshold
     value: ${{ steps.gate.outputs.threshold_findings }}
 
 runs:
-  using: "composite"
+  using: composite
 
   steps:
     - name: Install Trivy
@@ -58,10 +60,12 @@ runs:
         TRIVY_BIN_DIR="$RUNNER_TEMP/trivy-bin"
         mkdir -p "$TRIVY_BIN_DIR"
 
-        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
-          | sh -s -- -b "$TRIVY_BIN_DIR"
+        curl -sfL \
+          https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh |
+          sh -s -- -b "$TRIVY_BIN_DIR"
 
         echo "$TRIVY_BIN_DIR" >> "$GITHUB_PATH"
+
         "$TRIVY_BIN_DIR/trivy" --version
 
     - name: Prepare report paths
@@ -76,7 +80,12 @@ runs:
           APP_NAME="scan"
         fi
 
-        SAFE_APP_NAME="$(printf '%s' "$APP_NAME" | tr ' /' '--' | tr -cd '[:alnum:]._:-')"
+        SAFE_APP_NAME="$(
+          printf '%s' "$APP_NAME" |
+          tr ' /' '--' |
+          tr -cd '[:alnum:]._:-'
+        )"
+
         REPORT_DIR="${{ inputs.output-dir }}"
 
         mkdir -p "$REPORT_DIR"
@@ -100,20 +109,23 @@ runs:
         TRIVY_BIN="$RUNNER_TEMP/trivy-bin/trivy"
         JSON_FILE="${{ steps.meta.outputs.json_file }}"
         HTML_FILE="${{ steps.meta.outputs.html_file }}"
+        MD_FILE="${{ steps.meta.outputs.md_file }}"
         IMAGE_REF="${{ inputs.image-ref }}"
 
-        LICENSE_FULL_FLAG=""
+        trivy_args=(
+          image
+          --scanners vuln,license
+          --format json
+          --output "$JSON_FILE"
+        )
 
         if [ "${{ inputs.license-full }}" = "true" ]; then
-          LICENSE_FULL_FLAG="--license-full"
+          trivy_args+=(--license-full)
         fi
 
-        "$TRIVY_BIN" image \
-          --scanners vuln,license \
-          $LICENSE_FULL_FLAG \
-          --format json \
-          --output "$JSON_FILE" \
-          "$IMAGE_REF"
+        trivy_args+=("$IMAGE_REF")
+
+        "$TRIVY_BIN" "${trivy_args[@]}"
 
         node "${{ github.action_path }}/render-trivy-html.mjs" \
           "$JSON_FILE" \
@@ -121,7 +133,7 @@ runs:
 
         echo "json_path=$JSON_FILE" >> "$GITHUB_OUTPUT"
         echo "html_path=$HTML_FILE" >> "$GITHUB_OUTPUT"
-        echo "markdown_path=${{ steps.meta.outputs.md_file }}" >> "$GITHUB_OUTPUT"
+        echo "markdown_path=$MD_FILE" >> "$GITHUB_OUTPUT"
 
     - name: Create markdown summary
       shell: bash
@@ -142,68 +154,76 @@ runs:
           jq -r "$1 | length" "$JSON_FILE"
         }
 
-        CRIT_VULN=$(jq_count '[.Results[]? | .Vulnerabilities[]? | select((.Severity // "" | ascii_upcase) == "CRITICAL")]')
-        HIGH_VULN=$(jq_count '[.Results[]? | .Vulnerabilities[]? | select((.Severity // "" | ascii_upcase) == "HIGH")]')
-        MED_VULN=$(jq_count '[.Results[]? | .Vulnerabilities[]? | select((.Severity // "" | ascii_upcase) == "MEDIUM")]')
-        LOW_VULN=$(jq_count '[.Results[]? | .Vulnerabilities[]? | select((.Severity // "" | ascii_upcase) == "LOW")]')
-        UNK_VULN=$(jq_count '[.Results[]? | .Vulnerabilities[]? | select((.Severity // "" | ascii_upcase) == "UNKNOWN")]')
+        CRIT_VULN="$(jq_count '[.Results[]? | .Vulnerabilities[]? | select(((.Severity // "") | ascii_upcase) == "CRITICAL")]')"
+        HIGH_VULN="$(jq_count '[.Results[]? | .Vulnerabilities[]? | select(((.Severity // "") | ascii_upcase) == "HIGH")]')"
+        MED_VULN="$(jq_count '[.Results[]? | .Vulnerabilities[]? | select(((.Severity // "") | ascii_upcase) == "MEDIUM")]')"
+        LOW_VULN="$(jq_count '[.Results[]? | .Vulnerabilities[]? | select(((.Severity // "") | ascii_upcase) == "LOW")]')"
+        UNK_VULN="$(jq_count '[.Results[]? | .Vulnerabilities[]? | select(((.Severity // "") | ascii_upcase) == "UNKNOWN")]')"
 
-        CRIT_LICENSE=$(jq_count '[.Results[]? | .Licenses[]? | select((.Severity // "" | ascii_upcase) == "CRITICAL")]')
-        HIGH_LICENSE=$(jq_count '[.Results[]? | .Licenses[]? | select((.Severity // "" | ascii_upcase) == "HIGH")]')
-        MED_LICENSE=$(jq_count '[.Results[]? | .Licenses[]? | select((.Severity // "" | ascii_upcase) == "MEDIUM")]')
-        LOW_LICENSE=$(jq_count '[.Results[]? | .Licenses[]? | select((.Severity // "" | ascii_upcase) == "LOW")]')
-        UNK_LICENSE=$(jq_count '[.Results[]? | .Licenses[]? | select((.Severity // "" | ascii_upcase) == "UNKNOWN")]')
+        CRIT_LICENSE="$(jq_count '[.Results[]? | .Licenses[]? | select(((.Severity // "") | ascii_upcase) == "CRITICAL")]')"
+        HIGH_LICENSE="$(jq_count '[.Results[]? | .Licenses[]? | select(((.Severity // "") | ascii_upcase) == "HIGH")]')"
+        MED_LICENSE="$(jq_count '[.Results[]? | .Licenses[]? | select(((.Severity // "") | ascii_upcase) == "MEDIUM")]')"
+        LOW_LICENSE="$(jq_count '[.Results[]? | .Licenses[]? | select(((.Severity // "") | ascii_upcase) == "LOW")]')"
+        UNK_LICENSE="$(jq_count '[.Results[]? | .Licenses[]? | select(((.Severity // "") | ascii_upcase) == "UNKNOWN")]')"
 
         : > "$MD_FILE"
 
-        printf '%s\n' "# Trivy Scan Summary" >> "$MD_FILE"
-        printf '\n' >> "$MD_FILE"
+        printf '# Trivy Scan Summary\n\n' >> "$MD_FILE"
         printf 'Image: `%s`\n\n' "$IMAGE_REF" >> "$MD_FILE"
         printf 'Blocking vulnerability severities: `%s`\n\n' "$SEVERITY_THRESHOLD" >> "$MD_FILE"
-        printf '%s\n\n' "---" >> "$MD_FILE"
+        printf '%s\n\n' '---' >> "$MD_FILE"
 
-        printf '%s\n\n' "## Vulnerabilities" >> "$MD_FILE"
-        printf '%s\n' "<table>" >> "$MD_FILE"
-        printf '%s\n' "  <tr><th>Severity</th><th>Count</th></tr>" >> "$MD_FILE"
-        printf '%s\n' "  <tr><td>Critical</td><td>${CRIT_VULN}</td></tr>" >> "$MD_FILE"
-        printf '%s\n' "  <tr><td>High</td><td>${HIGH_VULN}</td></tr>" >> "$MD_FILE"
-        printf '%s\n' "  <tr><td>Medium</td><td>${MED_VULN}</td></tr>" >> "$MD_FILE"
-        printf '%s\n' "  <tr><td>Low</td><td>${LOW_VULN}</td></tr>" >> "$MD_FILE"
-        printf '%s\n' "  <tr><td>Unknown</td><td>${UNK_VULN}</td></tr>" >> "$MD_FILE"
-        printf '%s\n\n' "</table>" >> "$MD_FILE"
+        printf '## Vulnerabilities\n\n' >> "$MD_FILE"
+        printf '%s\n' '<table>' >> "$MD_FILE"
+        printf '%s\n' '  <tr><th>Severity</th><th>Count</th></tr>' >> "$MD_FILE"
+        printf '  <tr><td>Critical</td><td>%s</td></tr>\n' "$CRIT_VULN" >> "$MD_FILE"
+        printf '  <tr><td>High</td><td>%s</td></tr>\n' "$HIGH_VULN" >> "$MD_FILE"
+        printf '  <tr><td>Medium</td><td>%s</td></tr>\n' "$MED_VULN" >> "$MD_FILE"
+        printf '  <tr><td>Low</td><td>%s</td></tr>\n' "$LOW_VULN" >> "$MD_FILE"
+        printf '  <tr><td>Unknown</td><td>%s</td></tr>\n' "$UNK_VULN" >> "$MD_FILE"
+        printf '%s\n\n' '</table>' >> "$MD_FILE"
 
-        printf '%s\n\n' "## Licenses" >> "$MD_FILE"
-        printf '%s\n' "<table>" >> "$MD_FILE"
-        printf '%s\n' "  <tr><th>Severity</th><th>Count</th></tr>" >> "$MD_FILE"
-        printf '%s\n' "  <tr><td>Critical</td><td>${CRIT_LICENSE}</td></tr>" >> "$MD_FILE"
-        printf '%s\n' "  <tr><td>High</td><td>${HIGH_LICENSE}</td></tr>" >> "$MD_FILE"
-        printf '%s\n' "  <tr><td>Medium</td><td>${MED_LICENSE}</td></tr>" >> "$MD_FILE"
-        printf '%s\n' "  <tr><td>Low</td><td>${LOW_LICENSE}</td></tr>" >> "$MD_FILE"
-        printf '%s\n' "  <tr><td>Unknown</td><td>${UNK_LICENSE}</td></tr>" >> "$MD_FILE"
-        printf '%s\n\n' "</table>" >> "$MD_FILE"
+        printf '## Licenses\n\n' >> "$MD_FILE"
+        printf '%s\n' '<table>' >> "$MD_FILE"
+        printf '%s\n' '  <tr><th>Severity</th><th>Count</th></tr>' >> "$MD_FILE"
+        printf '  <tr><td>Critical</td><td>%s</td></tr>\n' "$CRIT_LICENSE" >> "$MD_FILE"
+        printf '  <tr><td>High</td><td>%s</td></tr>\n' "$HIGH_LICENSE" >> "$MD_FILE"
+        printf '  <tr><td>Medium</td><td>%s</td></tr>\n' "$MED_LICENSE" >> "$MD_FILE"
+        printf '  <tr><td>Low</td><td>%s</td></tr>\n' "$LOW_LICENSE" >> "$MD_FILE"
+        printf '  <tr><td>Unknown</td><td>%s</td></tr>\n' "$UNK_LICENSE" >> "$MD_FILE"
+        printf '%s\n\n' '</table>' >> "$MD_FILE"
 
-        printf '%s\n' "---" >> "$MD_FILE"
+        printf '%s\n' '---' >> "$MD_FILE"
 
-        echo "Wrote markdown to $MD_FILE"
+        echo "Wrote markdown report to $MD_FILE"
 
-        if [ -n "${GITHUB_STEP_SUMMARY:-}" ] && [ -f "$MD_FILE" ]; then
+        if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
           cat "$MD_FILE" >> "$GITHUB_STEP_SUMMARY"
-          echo "Appended markdown to GitHub Actions summary."
         fi
 
+    - name: Upload Trivy JSON report
+      if: always() && steps.scan.outputs.json_path != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: trivy-scan-json--${{ steps.meta.outputs.app_name }}-${{ github.run_number }}
+        path: ${{ steps.scan.outputs.json_path }}
+        if-no-files-found: error
+
     - name: Upload Trivy HTML report
-      if: always()
+      if: always() && steps.scan.outputs.html_path != ''
       uses: actions/upload-artifact@v4
       with:
         name: trivy-scan-html--${{ steps.meta.outputs.app_name }}-${{ github.run_number }}
         path: ${{ steps.scan.outputs.html_path }}
+        if-no-files-found: error
 
     - name: Upload Trivy markdown report
-      if: always()
+      if: always() && steps.scan.outputs.markdown_path != ''
       uses: actions/upload-artifact@v4
       with:
         name: trivy-scan-md--${{ steps.meta.outputs.app_name }}-${{ github.run_number }}
         path: ${{ steps.scan.outputs.markdown_path }}
+        if-no-files-found: error
 
     - name: Evaluate Trivy vulnerability threshold
       id: gate
@@ -211,52 +231,54 @@ runs:
       run: |
         set -euo pipefail
 
-        if [ "${{ inputs.fail-build }}" != "true" ]; then
-          echo "threshold_findings=0" >> "$GITHUB_OUTPUT"
-          echo "Trivy vulnerability gate is disabled."
-          exit 0
-        fi
-
         JSON_FILE="${{ steps.scan.outputs.json_path }}"
         SEVERITY_THRESHOLD="${{ inputs.severity-threshold }}"
+        FAIL_BUILD="${{ inputs.fail-build }}"
 
         if [ -z "$JSON_FILE" ] || [ ! -f "$JSON_FILE" ]; then
           echo "::error::Trivy JSON report was not generated."
           exit 1
         fi
 
-        THRESHOLD_FINDINGS=$(jq -r \
-          --arg severities "$SEVERITY_THRESHOLD" '
-            def allowed:
-              (
-                $severities
-                | split(",")
-                | map(
-                    gsub("^\\s+|\\s+$"; "")
-                    | ascii_upcase
-                  )
-              );
+        THRESHOLD_FINDINGS="$(
+          jq -r \
+            --arg severities "$SEVERITY_THRESHOLD" '
+              def allowed:
+                (
+                  $severities
+                  | split(",")
+                  | map(
+                      gsub("^\\s+|\\s+$"; "")
+                      | ascii_upcase
+                    )
+                );
 
-            def matches_threshold:
-              (
-                (.Severity // .severity // "" | ascii_upcase) as $severity
-                | (allowed | index($severity)) != null
-              );
+              def matches_threshold:
+                (
+                  ((.Severity // .severity // "") | ascii_upcase) as $severity
+                  | (allowed | index($severity)) != null
+                );
 
-            [
-              .Results[]?
-              | .Vulnerabilities[]?
-              | select(matches_threshold)
-            ]
-            | length
-          ' "$JSON_FILE")
+              [
+                .Results[]?
+                | .Vulnerabilities[]?
+                | select(matches_threshold)
+              ]
+              | length
+            ' "$JSON_FILE"
+        )"
 
         echo "threshold_findings=$THRESHOLD_FINDINGS" >> "$GITHUB_OUTPUT"
-        echo "Trivy High/Critical vulnerability count: $THRESHOLD_FINDINGS"
+        echo "Trivy threshold vulnerability count: $THRESHOLD_FINDINGS"
 
         if [ "$THRESHOLD_FINDINGS" -gt 0 ]; then
-          echo "::error::Trivy found $THRESHOLD_FINDINGS vulnerabilities matching threshold '$SEVERITY_THRESHOLD'."
-          exit 1
+          if [ "$FAIL_BUILD" = "true" ]; then
+            echo "::error::Trivy found $THRESHOLD_FINDINGS vulnerabilities matching threshold '$SEVERITY_THRESHOLD'."
+            exit 1
+          fi
+
+          echo "::warning::Trivy found $THRESHOLD_FINDINGS vulnerabilities matching threshold '$SEVERITY_THRESHOLD'. Blocking is disabled for this application."
+          exit 0
         fi
 
         echo "No vulnerabilities matched Trivy threshold '$SEVERITY_THRESHOLD'."

--- a/build-image/upload-sast-report/action.yaml
+++ b/build-image/upload-sast-report/action.yaml
@@ -1,16 +1,21 @@
 name: Run SAST
-description: Run SAST, upload the SARIF report, and fail for High or Critical findings
+description: Run Bearer SAST, upload the SARIF report, and optionally fail for High or Critical findings
 
 inputs:
   working-directory:
-    default: .
     required: false
+    default: "."
 
   app-name:
     required: true
 
+  fail-build:
+    description: Fail the workflow when Bearer finds High or Critical findings
+    required: false
+    default: "false"
+
 runs:
-  using: "composite"
+  using: composite
 
   steps:
     - name: Install SAST CLI
@@ -19,8 +24,9 @@ runs:
       run: |
         set -euo pipefail
 
-        curl -sfL https://raw.githubusercontent.com/Bearer/bearer/main/contrib/install.sh \
-          | sh -s -- latest
+        curl -sfL \
+          https://raw.githubusercontent.com/Bearer/bearer/main/contrib/install.sh |
+          sh -s -- latest
 
         echo "$PWD/bin" >> "$GITHUB_PATH"
 
@@ -32,6 +38,7 @@ runs:
         set -u
 
         REPORT_FILE="sast-report-${{ inputs.app-name }}-${{ github.run_number }}.sarif"
+        REPORT_PATH="$PWD/$REPORT_FILE"
 
         set +e
 
@@ -48,14 +55,14 @@ runs:
 
         set -e
 
-        echo "report_file=$REPORT_FILE" >> "$GITHUB_OUTPUT"
+        echo "report_file=$REPORT_PATH" >> "$GITHUB_OUTPUT"
         echo "scan_exit_code=$SCAN_EXIT_CODE" >> "$GITHUB_OUTPUT"
 
-        # Allow report upload before failing the gate.
+        # Always allow the artifact upload step to execute.
         exit 0
 
     - name: Upload SAST security report
-      if: always()
+      if: always() && steps.sast_scan.outputs.report_file != ''
       uses: actions/upload-artifact@v4
       with:
         name: sast-report-${{ inputs.app-name }}-${{ github.run_number }}
@@ -69,15 +76,26 @@ runs:
         set -euo pipefail
 
         SCAN_EXIT_CODE="${{ steps.sast_scan.outputs.scan_exit_code }}"
+        FAIL_BUILD="${{ inputs.fail-build }}"
 
         if [ -z "$SCAN_EXIT_CODE" ]; then
           echo "::error::SAST scan did not complete successfully."
           exit 1
         fi
 
-        if [ "$SCAN_EXIT_CODE" -ne 0 ]; then
-          echo "::error::SAST found High or Critical security findings."
+        if ! [[ "$SCAN_EXIT_CODE" =~ ^[0-9]+$ ]]; then
+          echo "::error::Invalid SAST scan exit code: $SCAN_EXIT_CODE"
           exit 1
+        fi
+
+        if [ "$SCAN_EXIT_CODE" -ne 0 ]; then
+          if [ "$FAIL_BUILD" = "true" ]; then
+            echo "::error::SAST found High or Critical security findings."
+            exit 1
+          fi
+
+          echo "::warning::SAST found High or Critical security findings. Blocking is disabled for this application."
+          exit 0
         fi
 
         echo "No High or Critical SAST findings detected."


### PR DESCRIPTION
- Adds configurable security-fail-build support to shared appdev-workflows.
- Keeps JFrog, Trivy and SAST scans enabled while making PR blocking opt-in.
- Existing consuming repositories continue to generate scan reports without failing PRs.
- Applications can enable blocking on High/Critical findings by setting security-fail-build: true.