### PR TITLE
ci: update build-image workflow to use Java 21 for Sonar compatibility (DCD-5081)

### DIFF
--- a/build-image/action.yaml
+++ b/build-image/action.yaml
@@ -112,7 +112,7 @@ runs:
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        java-version: "17"
+        java-version: "21"
         distribution: adopt
 
     - name: Install lmdb-devel

--- a/build-image/action.yaml
+++ b/build-image/action.yaml
@@ -112,7 +112,7 @@ runs:
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        java-version: "21"
+        java-version: "17"
         distribution: adopt
 
     - name: Install lmdb-devel

--- a/build-image/upload-test-coverage/action.yaml
+++ b/build-image/upload-test-coverage/action.yaml
@@ -36,11 +36,24 @@ runs:
           exit 1
         fi
 
+    - name: Set up Java 21 for Sonar
+      uses: actions/setup-java@v4
+      with:
+        java-version: "21"
+        distribution: adopt
+
     - name: Upload test coverage
       shell: bash
       working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
       run: |
         ./gradlew jacocoTestReport sonarqube -Pversion=${{ inputs.version }} --no-configuration-cache --no-build-cache --stacktrace -PgenesisArtifactoryUser="${{ inputs.jfrog-username }}" -PgenesisArtifactoryPassword="${{ inputs.jfrog-password }}" -Dsonar.token="${{ inputs.sonar-token }}"
+
+    - name: Restore Java 17
+      if: always()
+      uses: actions/setup-java@v4
+      with:
+        java-version: "17"
+        distribution: adopt
 
     - name: Upload Test Reports
       uses: actions/upload-artifact@v4


### PR DESCRIPTION

SonarQube Cloud has deprecated Java 17 for running analysis, causing Sonar scans to fail with:
"The version of Java (17) used to run this analysis is deprecated, and SonarQube Cloud no longer supports it."



