### PR TITLE
ci: Adding code for Sonar to use Java 21 (DCD-5102)

### DIFF
--- a/.github/workflows/build-and-generate-rpm.yml
+++ b/.github/workflows/build-and-generate-rpm.yml
@@ -411,7 +411,27 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: >
-            test jacocoTestReport sonarqube --no-build-cache --stacktrace
+            test jacocoTestReport --no-build-cache --stacktrace
+            -PpushToCache=${{ inputs.push-to-artifactory-cache }}
+            -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }}
+            ${{ env.SERVER_BUILD_ARGS }}
+            -PuseDevRepo=true
+          build-root-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
+          cache-disabled: true
+
+      - name: Set up Java 21 for Sonar
+        if: inputs.build_server && !inputs.skip-tests
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: adopt
+
+      - name: Run Sonar analysis
+        if: inputs.build_server && !inputs.skip-tests
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: >
+            sonarqube --no-build-cache --stacktrace
             -PpushToCache=${{ inputs.push-to-artifactory-cache }}
             -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }}
             ${{ env.SERVER_BUILD_ARGS }}
@@ -420,6 +440,13 @@ jobs:
             -Dsonar.token=${{ secrets.JENKINSGENESIS_SONAR }}
           build-root-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
           cache-disabled: true
+
+      - name: Restore Java 17
+        if: inputs.build_server && !inputs.skip-tests
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ inputs.java_version }}
+          distribution: adopt
 
       - name: Copy Test Reports
         working-directory: "${{ inputs.working-directory }}"


### PR DESCRIPTION
- Split the combined test jacocoTestReport sonarqube Gradle task.
- Continue running application build, tests, and JaCoCo using Java 17.
- Switch to Java 21 only for the Sonar analysis step to meet SonarCloud's Java 21 requirement.
- Restore Java 17 after Sonar so the remaining RPM build continues to use Java 17.