### PR TITLE
fix: allow colon before appDistZip in task-detection grep(DCD-5100)

### DIFF
--- a/build-image/jfrog-scanning/action.yaml
+++ b/build-image/jfrog-scanning/action.yaml
@@ -95,7 +95,7 @@ runs:
           "${gradle_args[@]}" \
           ${{ inputs.build-server-arguments }} \
           2>/dev/null |
-          grep -qE '(^|[[:space:]])appDistZip([[:space:]]|$)'; then
+          grep -qE '(^|[[:space:]:])appDistZip([[:space:]]|$)'; then
           echo "appDistZip=true" >> "$GITHUB_OUTPUT"
           echo "appDistZip task is available."
         else


### PR DESCRIPTION
Multi-module gradle builds list subproject tasks as e.g. tam-deploy:appDistZip — the word-boundary regex added in 87065f4 didn't account for the colon, so appDistZip was never detected and the JFrog scan step was silently skipped for every client.