### PR TITLE
fix: Updated scan files for printing artifacts (DCD-5102)

### DIFF
--- a/build-image/jfrog-scanning/action.yaml
+++ b/build-image/jfrog-scanning/action.yaml
@@ -193,6 +193,14 @@ runs:
       with:
         json_path: ${{ steps.scan.outputs.full_report_file }}
 
+    - name: Upload JFrog markdown summary
+      if: always() && steps.scan.outputs.full_report_file != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: xray-scan-md--${{ inputs.app-name }}-${{ github.run_number }}
+        path: ${{ github.workspace }}/scan-summary.md
+        if-no-files-found: error
+
     - name: Upload JFrog full scan report
       if: always() && steps.scan.outputs.full_report_file != ''
       uses: actions/upload-artifact@v4

--- a/build-image/upload-test-coverage/action.yaml
+++ b/build-image/upload-test-coverage/action.yaml
@@ -60,7 +60,8 @@ runs:
       if: always()
       with:
         name: test-reports${{ inputs.test-reports-suffix }}
-        path: "${{ inputs.working-directory }}/${{ inputs.server-path }}/*/build/reports/**/*"
+        path: "${{ github.workspace }}/${{ inputs.working-directory }}/${{ inputs.server-path }}/*/build/reports/**/*"
+        if-no-files-found: ignore
 
     - name: Publish All Test Results
       uses: EnricoMi/publish-unit-test-result-action@v2


### PR DESCRIPTION
This PR updates GitHub Actions artifact uploading for build-image workflows so scan outputs are published more reliably.