### PR TITLE
fix: Sonar fix (DCD-5102)

### DIFF
--- a/.github/workflows/build-and-generate-rpm.yml
+++ b/.github/workflows/build-and-generate-rpm.yml
@@ -85,6 +85,18 @@ on:
         required: false
         type: boolean
         default: true
+      sonar_enabled:
+        required: false
+        type: boolean
+        default: false
+      sonar_java_version:
+        required: false
+        type: string
+        default: "21"
+      sonar_java_distribution:
+        required: false
+        type: string
+        default: "temurin"
       include-xray-report:
         required: false
         type: boolean
@@ -419,35 +431,6 @@ jobs:
           build-root-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
           cache-disabled: true
 
-      - name: Set up Java 21 for Sonar
-        if: inputs.build_server && !inputs.skip-tests
-        uses: actions/setup-java@v4
-        with:
-          java-version: "21"
-          distribution: adopt
-
-      - name: Run Sonar analysis
-        if: inputs.build_server && !inputs.skip-tests
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: >
-            sonarqube --no-build-cache --stacktrace
-            -PpushToCache=${{ inputs.push-to-artifactory-cache }}
-            -PdisableRemoteCache=${{ !inputs.use-artifactory-cache }}
-            ${{ env.SERVER_BUILD_ARGS }}
-            -PuseDevRepo=true
-            -Dsonar.gradle.skipCompile=true
-            -Dsonar.token=${{ secrets.JENKINSGENESIS_SONAR }}
-          build-root-directory: "${{ inputs.working-directory }}/${{ inputs.server-path }}"
-          cache-disabled: true
-
-      - name: Restore Java 17
-        if: inputs.build_server && !inputs.skip-tests
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ inputs.java_version }}
-          distribution: adopt
-
       - name: Copy Test Reports
         working-directory: "${{ inputs.working-directory }}"
         shell: bash
@@ -714,3 +697,25 @@ jobs:
           ls -al
           uploaded_rpm_name=$(ls -1 *.rpm)
           echo "uploaded_rpm_name=$uploaded_rpm_name" >> $GITHUB_OUTPUT
+
+  sonar:
+    name: SonarCloud Analysis
+    if: ${{ inputs.sonar_enabled && inputs.build_server && !inputs.skip-tests }}
+    uses: ./.github/workflows/sonarcloud.yml
+    with:
+      branch: ${{ inputs.branch }}
+      version: ${{ inputs.version }}
+      working-directory: ${{ inputs.working-directory }}
+      server-path: ${{ inputs.server-path }}
+      project_java_version: ${{ inputs.java_version }}
+      project_java_distribution: temurin
+      sonar_java_version: ${{ inputs.sonar_java_version }}
+      sonar_java_distribution: ${{ inputs.sonar_java_distribution }}
+      node_version: ${{ inputs.node_version }}
+    secrets:
+      GPR_READ_TOKEN: ${{ secrets.GPR_READ_TOKEN }}
+      GRADLE_PROPERTIES: ${{ secrets.GRADLE_PROPERTIES }}
+      JFROG_USERNAME: ${{ secrets.JFROG_USERNAME }}
+      JFROG_EMAIL: ${{ secrets.JFROG_EMAIL }}
+      JFROG_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
+      JENKINSGENESIS_SONAR: ${{ secrets.JENKINSGENESIS_SONAR }}

--- a/.github/workflows/build-and-generate-rpm.yml
+++ b/.github/workflows/build-and-generate-rpm.yml
@@ -85,18 +85,6 @@ on:
         required: false
         type: boolean
         default: true
-      sonar_enabled:
-        required: false
-        type: boolean
-        default: false
-      sonar_java_version:
-        required: false
-        type: string
-        default: "21"
-      sonar_java_distribution:
-        required: false
-        type: string
-        default: "temurin"
       include-xray-report:
         required: false
         type: boolean
@@ -700,7 +688,7 @@ jobs:
 
   sonar:
     name: SonarCloud Analysis
-    if: ${{ inputs.sonar_enabled && inputs.build_server && !inputs.skip-tests }}
+    if: ${{ inputs.build_server && !inputs.skip-tests }}
     uses: ./.github/workflows/sonarcloud.yml
     with:
       branch: ${{ inputs.branch }}
@@ -709,8 +697,6 @@ jobs:
       server-path: ${{ inputs.server-path }}
       project_java_version: ${{ inputs.java_version }}
       project_java_distribution: temurin
-      sonar_java_version: ${{ inputs.sonar_java_version }}
-      sonar_java_distribution: ${{ inputs.sonar_java_distribution }}
       node_version: ${{ inputs.node_version }}
     secrets:
       GPR_READ_TOKEN: ${{ secrets.GPR_READ_TOKEN }}

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -97,14 +97,6 @@ on:
         type: boolean
         required: false
         default: false
-      sonar_java_version:
-        type: string
-        required: false
-        default: '21'
-      sonar_java_distribution:
-        type: string
-        required: false
-        default: 'temurin'
       sast:
         required: false
         default: true
@@ -500,8 +492,6 @@ jobs:
       server-path: '${{ inputs.working-directory }}/server'
       project_java_version: ${{ inputs.java_version }}
       project_java_distribution: temurin
-      sonar_java_version: ${{ inputs.sonar_java_version }}
-      sonar_java_distribution: ${{ inputs.sonar_java_distribution }}
       node_version: ${{ inputs.node_version }}
       REGISTRY_URL: ${{ inputs.REGISTRY_URL }}
       SCOPE: ${{ inputs.SCOPE }}

--- a/.github/workflows/build-gradle-g8.yml
+++ b/.github/workflows/build-gradle-g8.yml
@@ -97,6 +97,14 @@ on:
         type: boolean
         required: false
         default: false
+      sonar_java_version:
+        type: string
+        required: false
+        default: '21'
+      sonar_java_distribution:
+        type: string
+        required: false
+        default: 'temurin'
       sast:
         required: false
         default: true
@@ -488,7 +496,12 @@ jobs:
     with:
       branch: ${{ inputs.branch }}
       version: ${{ inputs.version }}
+      working-directory: ${{ inputs.working-directory }}
       server-path: '${{ inputs.working-directory }}/server'
+      project_java_version: ${{ inputs.java_version }}
+      project_java_distribution: temurin
+      sonar_java_version: ${{ inputs.sonar_java_version }}
+      sonar_java_distribution: ${{ inputs.sonar_java_distribution }}
       node_version: ${{ inputs.node_version }}
       REGISTRY_URL: ${{ inputs.REGISTRY_URL }}
       SCOPE: ${{ inputs.SCOPE }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -26,6 +26,21 @@ on:
         required: false
         type: string
         default: '17'
+      project_java_distribution:
+        description: Distribution used for the application build JDK
+        required: false
+        type: string
+        default: 'temurin'
+      sonar_java_version:
+        description: Java version used to run the Sonar analysis
+        required: false
+        type: string
+        default: '21'
+      sonar_java_distribution:
+        description: Distribution used for the Sonar analysis JDK
+        required: false
+        type: string
+        default: 'temurin'
       node_version:
         description: Node.js version required by the project
         required: false
@@ -71,7 +86,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: ${{ inputs.project_java_version }}
-          distribution: temurin
+          distribution: ${{ inputs.project_java_distribution }}
       - name: Configure Node
         if: ${{ !inputs.REGISTRY_URL }}
         uses: actions/setup-node@v4
@@ -151,11 +166,11 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.branch }}
-      - name: Set up JDK 21 for Sonar
+      - name: Set up JDK for Sonar
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: temurin
+          java-version: ${{ inputs.sonar_java_version }}
+          distribution: ${{ inputs.sonar_java_distribution }}
       - name: Configure Node
         if: ${{ !inputs.REGISTRY_URL }}
         uses: actions/setup-node@v4

--- a/build-image/action.yaml
+++ b/build-image/action.yaml
@@ -102,6 +102,14 @@ inputs:
     required: false
     default: "false"
 
+  sonar-java-version:
+    required: false
+    default: "21"
+
+  sonar-java-distribution:
+    required: false
+    default: "temurin"
+
   JENKINSGENESIS_SONAR:
     required: false
 
@@ -246,6 +254,8 @@ runs:
         working-directory: ${{ inputs.working-directory }}
         server-path: ${{ inputs.server-path }}
         sonar-token: ${{ inputs.sonar-token }}
+        sonar-java-version: ${{ inputs.sonar-java-version }}
+        sonar-java-distribution: ${{ inputs.sonar-java-distribution }}
 
     - name: Check Auth Permissions task
       id: auth_permissions_task

--- a/build-image/upload-test-coverage/action.yaml
+++ b/build-image/upload-test-coverage/action.yaml
@@ -21,6 +21,12 @@ inputs:
     required: false
   sonar-token:
     required: true
+  sonar-java-version:
+    required: false
+    default: "21"
+  sonar-java-distribution:
+    required: false
+    default: "temurin"
 
 runs:
   using: "composite"
@@ -36,19 +42,19 @@ runs:
           exit 1
         fi
 
-    - name: Set up Java 21 for Sonar
+    - name: Set up Java for Sonar
       uses: actions/setup-java@v4
       with:
-        java-version: "21"
-        distribution: adopt
+        java-version: ${{ inputs.sonar-java-version }}
+        distribution: ${{ inputs.sonar-java-distribution }}
 
     - name: Upload test coverage
       shell: bash
       working-directory: ${{ inputs.working-directory }}/${{ inputs.server-path }}/
       run: |
-        ./gradlew jacocoTestReport sonarqube -Pversion=${{ inputs.version }} --no-configuration-cache --no-build-cache --stacktrace -PgenesisArtifactoryUser="${{ inputs.jfrog-username }}" -PgenesisArtifactoryPassword="${{ inputs.jfrog-password }}" -Dsonar.token="${{ inputs.sonar-token }}"
+        ./gradlew jacocoTestReport sonar -Pversion=${{ inputs.version }} --no-configuration-cache --no-build-cache --stacktrace -PgenesisArtifactoryUser="${{ inputs.jfrog-username }}" -PgenesisArtifactoryPassword="${{ inputs.jfrog-password }}" -Dsonar.token="${{ inputs.sonar-token }}"
 
-    - name: Restore Java 17
+    - name: Restore Java for build
       if: always()
       uses: actions/setup-java@v4
       with:


### PR DESCRIPTION
- Centralized Sonar handling in the shared workflow
- Made the Sonar JDK version configurable
- Updated the Sonar Gradle task from the deprecated Sonar plugin path to the supported task
- Wired the reusable workflow into the main build workflows so the logic is maintained in one place