### PR TITLE
fix: stop matching product versions as Jira issue keys (TAMTECH-598)

### DIFF
--- a/.github/workflows/set-fix-version.yml
+++ b/.github/workflows/set-fix-version.yml
@@ -101,7 +101,8 @@ jobs:
               COMMIT_MSG=$(echo "$COMMIT" | cut -d ' ' -f 2-)
               echo "Processing commit: $COMMIT_HASH $COMMIT_MSG"
 
-              JIRAS=$(echo "$COMMIT_MSG" | grep -oE '[A-Z]+-[0-9]+' || true)
+              # (?!\.\d) so product versions like TAM-8.26 are not parsed as TAM-8.
+              JIRAS=$(echo "$COMMIT_MSG" | grep -oP '[A-Z]+-[0-9]+(?!\.\d)' || true)
               if [ -z "$JIRAS" ]; then
                 echo "Skipping commit (no Jira ID): $COMMIT_HASH - $COMMIT_MSG"
                 continue


### PR DESCRIPTION
## Summary
- Tighten Jira key extraction from `[A-Z]+-[0-9]+` to `[A-Z]+-[0-9]+(?!\.\d)` so commit subjects like `14.427.1-TAM-8.26-patch.1` and `ak/TAM-8.26-patch-2` are not treated as issue `TAM-8`.
- This was tagging archived [TAM-8](https://genesisglobal.atlassian.net/browse/TAM-8) with modern `TAM_8.x` fix versions during RPM builds.

Ticket: [TAMTECH-598](https://genesisglobal.atlassian.net/browse/TAMTECH-598)

## Test plan
- [ ] Confirm a commit subject containing `TAM-8.26` no longer emits `TAM-8` in the extract step logs
- [ ] Confirm real keys such as `HT-179`, `TAMTECH-470`, and `TPD-5297` are still extracted
- [ ] Dry-run tagging against a recent 8.26 range that includes the FUI patch commits and check TAM-8 is absent

[TAM-8]: https://genesisglobal.atlassian.net/browse/TAM-8?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TAMTECH-598]: https://genesisglobal.atlassian.net/browse/TAMTECH-598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ