### PR TITLE
fix: aws region for remote secret population (DCD-5277)

### DIFF
--- a/deploy/action.yaml
+++ b/deploy/action.yaml
@@ -138,6 +138,7 @@ runs:
           echo 'export GENESIS_VERSION=${{ inputs.version }}' >> /etc/profile.d/deploy.sh
           echo 'export APP_NAME=${{ inputs.app_name }}' >> /etc/profile.d/deploy.sh
           echo 'export AWS_ECR_REGISTRY=${{ inputs.ecr_registry }}' >> /etc/profile.d/deploy.sh
+          echo 'export REGION=${{ inputs.aws-region }}' >> /etc/profile.d/deploy.sh
           echo 'export AWS_REGION=${{ inputs.aws-region }}' >> /etc/profile.d/deploy.sh
           echo 'export AWS_DEFAULT_REGION=${{ inputs.aws-region }}' >> /etc/profile.d/deploy.sh
 

--- a/deploy/action.yaml
+++ b/deploy/action.yaml
@@ -138,6 +138,8 @@ runs:
           echo 'export GENESIS_VERSION=${{ inputs.version }}' >> /etc/profile.d/deploy.sh
           echo 'export APP_NAME=${{ inputs.app_name }}' >> /etc/profile.d/deploy.sh
           echo 'export AWS_ECR_REGISTRY=${{ inputs.ecr_registry }}' >> /etc/profile.d/deploy.sh
+          echo 'export AWS_REGION=${{ inputs.aws-region }}' >> /etc/profile.d/deploy.sh
+          echo 'export AWS_DEFAULT_REGION=${{ inputs.aws-region }}' >> /etc/profile.d/deploy.sh
 
           echo '${{ inputs.custom_env_vars }}' | while IFS='=' read -r key value; do
             if [[ -n $key ]]; then
@@ -257,5 +259,4 @@ runs:
     - shell: bash
       run: |
         echo "- ✅ Docker Pruned" >> $GITHUB_STEP_SUMMARY
-
 


### PR DESCRIPTION
Fixes deployment failures where populate_secrets generated an invalid Secrets Manager endpoint due to a missing AWS region.
Exports the existing aws-region input as AWS_REGION and AWS_DEFAULT_REGION on remote EC2 instances. 